### PR TITLE
3. Heatmap patrolling

### DIFF
--- a/Assets/Scripts/Map/Visualization/Patrolling/CoverageHeatMapVisualizationMode.cs
+++ b/Assets/Scripts/Map/Visualization/Patrolling/CoverageHeatMapVisualizationMode.cs
@@ -1,0 +1,34 @@
+using Maes.Statistics;
+
+using UnityEngine;
+
+namespace Maes.Map.Visualization.Patrolling
+{
+    public class PatrollingCoverageHeatMapVisualizationMode : IPatrollingVisualizationMode
+    {
+        private SimulationMap<PatrollingCell> _map;
+        private readonly int _logicTicksBeforeCold = GlobalSettings.TicksBeforeWaypointCoverageHeatMapCold;
+
+        public PatrollingCoverageHeatMapVisualizationMode(SimulationMap<PatrollingCell> map)
+        {
+            _map = map;
+        }
+
+        public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
+        {
+            visualizer.SetAllColors(_map, (cell) => CellToColor(cell, currentTick));
+        }
+
+        private Color32 CellToColor(PatrollingCell cell, int currentTick)
+        {
+            if (!cell.CanBeCovered) return ExplorationVisualizer.SolidColor;
+            if (!cell.IsCovered) return ExplorationVisualizer.StandardCellColor;
+            
+            var ticksSinceLastCovered = currentTick - cell.LastCoverageTimeInTicks;
+            float coldness = Mathf.Min((float) ticksSinceLastCovered / (float) _logicTicksBeforeCold, 1.0f);
+            return Color32.Lerp(ExplorationVisualizer.WarmColor, ExplorationVisualizer.ColdColor, coldness);
+        }
+    }
+    
+    
+}

--- a/Assets/Scripts/Map/Visualization/Patrolling/CoverageHeatMapVisualizationMode.cs.meta
+++ b/Assets/Scripts/Map/Visualization/Patrolling/CoverageHeatMapVisualizationMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c7d64c3ace33416b9ec9c67649aa21da
+timeCreated: 1731254904

--- a/Assets/Scripts/Map/Visualization/Patrolling/PatrollingHeatMapVisualizationMode.cs
+++ b/Assets/Scripts/Map/Visualization/Patrolling/PatrollingHeatMapVisualizationMode.cs
@@ -1,0 +1,50 @@
+// Copyright 2022 MAES
+// 
+// This file is part of MAES
+// 
+// MAES is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAES is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAES. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: Malte Z. Andreasen, Philip I. Holler and Magnus K. Jensen
+// 
+// Original repository: https://github.com/MalteZA/MAES
+
+using Maes.Statistics;
+
+using UnityEngine;
+
+namespace Maes.Map.Visualization.Patrolling {
+    internal class PatrollingHeatMapVisualizationMode : IPatrollingVisualizationMode {
+
+        private readonly SimulationMap<PatrollingCell> _map;
+        private readonly int _logicTicksBeforeCold = GlobalSettings.TicksBeforeWaypointCoverageHeatMapCold;
+
+        public PatrollingHeatMapVisualizationMode(SimulationMap<PatrollingCell> map) {
+            _map = map;
+        }
+
+        public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick) {
+            // The entire map has to be replaced every tick since all colors are time dependent
+            visualizer.SetAllColors(_map, (cell) => CellToColor(cell, currentTick));
+        }
+        
+        private Color32 CellToColor(PatrollingCell cell, int currentTick) {
+            if (!cell.IsExplorable) return ExplorationVisualizer.SolidColor;
+            if (!cell.IsExplored) return ExplorationVisualizer.StandardCellColor;
+ 
+            var ticksSinceLastExplored = currentTick - cell.LastExplorationTimeInTicks;
+            float coldness = Mathf.Min((float) ticksSinceLastExplored / (float) _logicTicksBeforeCold, 1.0f);
+            return Color32.Lerp(ExplorationVisualizer.WarmColor, ExplorationVisualizer.ColdColor, coldness);
+        }
+    }
+}

--- a/Assets/Scripts/Map/Visualization/Patrolling/PatrollingHeatMapVisualizationMode.cs.meta
+++ b/Assets/Scripts/Map/Visualization/Patrolling/PatrollingHeatMapVisualizationMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6dee96e16e5547c9be6eb7429bc6f446
+timeCreated: 1731255311

--- a/Assets/Scripts/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Trackers/PatrollingTracker.cs
@@ -5,6 +5,7 @@ using Maes.Map;
 using Maes.Map.MapGen;
 using Maes.Map.Visualization;
 using Maes.Map.Visualization.Patrolling;
+
 using Maes.Robot;
 using Maes.Simulation;
 using Maes.Statistics;
@@ -39,6 +40,7 @@ namespace Maes.Trackers
             Map = map;
             Vertices = map.Vertices.ToDictionary(vertex => vertex.Position, vertex => new VertexDetails(vertex));
             
+            _visualizer.meshRenderer.enabled = false;
             _currentVisualizationMode = new WaypointHeatMapVisualizationMode();
         }
 
@@ -82,13 +84,25 @@ namespace Maes.Trackers
             return Vertices.Values.Select(vertex => currentTick - vertex.LastTimeVisitedTick).ToArray();
         }
         
-        public void ShowWaypointHeatMap()
-        {
-            SetVisualizationMode(new WaypointHeatMapVisualizationMode());
-        }
         private void SetCompletedCycles()
         {
             CompletedCycles = Vertices.Values.Select(v => v.NumberOfVisits).Min();
+        }
+        
+        public void ShowWaypointHeatMap()
+        {
+            _visualizer.meshRenderer.enabled = false;
+            SetVisualizationMode(new WaypointHeatMapVisualizationMode());
+        }
+
+        public void ShowAllRobotCoverageHeatMap() {
+            _visualizer.meshRenderer.enabled = true;
+            SetVisualizationMode(new PatrollingCoverageHeatMapVisualizationMode(_map));
+        }
+
+        public void ShowAllRobotPatrollingHeatMap() {
+            _visualizer.meshRenderer.enabled = true;
+            SetVisualizationMode(new PatrollingHeatMapVisualizationMode(_map));
         }
     }
 }

--- a/Assets/Scripts/UI/SimulationInfoUIControllers/ExplorationInfoUIController.cs
+++ b/Assets/Scripts/UI/SimulationInfoUIControllers/ExplorationInfoUIController.cs
@@ -23,9 +23,6 @@ namespace Maes.UI.SimulationInfoUIControllers
         public Button AllCoverageHeatMapButton = null!;
         public Button SelectVisibleAreaButton = null!;
         public Button SelectedSlamMapButton = null!;
-        
-        private List<Button>? _mapVisualizationToggleGroup;
-        
 
         protected override void AfterStart()
         {
@@ -94,14 +91,6 @@ namespace Maes.UI.SimulationInfoUIControllers
                                        (explorationSimulation.ExplorationTracker.CoveredMiniTiles * 2 /
                                         explorationSimulation.SimulateTimeSeconds).ToString("#.0");
             // Covered tiles multiplied by two to convert from mini-tiles to triangles/cells ^
-        }
-
-        // Highlights the selected map visualization button
-        private void SelectVisualizationButton(Button selectedButton) {
-            foreach (var button in _mapVisualizationToggleGroup ?? Enumerable.Empty<Button>()) 
-                button.image.color = _mapVisualizationColor;
-
-            selectedButton.image.color = _mapVisualizationSelectedColor;
         }
 
         private void OnMapVisualizationModeChanged(IExplorationVisualizationMode mode) {

--- a/Assets/Scripts/UI/SimulationInfoUIControllers/SimulationInfoUIControllerBase.cs
+++ b/Assets/Scripts/UI/SimulationInfoUIControllers/SimulationInfoUIControllerBase.cs
@@ -19,6 +19,8 @@
 // 
 // Original repository: https://github.com/MalteZA/MAES
 
+using System.Collections.Generic;
+
 using Maes.Algorithms;
 using Maes.Simulation;
 using Maes.Simulation.SimulationScenarios;
@@ -59,12 +61,14 @@ namespace Maes.UI.SimulationInfoUIControllers {
         
         protected readonly Color _mapVisualizationColor = Color.white;
         protected readonly Color _mapVisualizationSelectedColor = new Color(150 / 255f, 200 / 255f, 150 / 255f);
+        
+        protected List<Button> _mapVisualizationToggleGroup = new();
 
         protected abstract void AfterStart();
 
         private void Start()
         {
-            // Set listeners for Tag visualization buttons 
+            /*// Set listeners for Tag visualization buttons 
             AllVisualizeTagsButton.onClick.AddListener(() => {
                 ExecuteAndRememberTagVisualization(sim => {
                     if (sim != null) {
@@ -81,7 +85,7 @@ namespace Maes.UI.SimulationInfoUIControllers {
                         }
                     }
                 });
-            });
+            });*/
             
             StickyCameraButton.onClick.AddListener(() => {
                 CameraController.singletonInstance.stickyCam = !CameraController.singletonInstance.stickyCam;
@@ -169,6 +173,14 @@ namespace Maes.UI.SimulationInfoUIControllers {
         public void UpdateStatistics(ISimulation? simulation)
         { 
             UpdateStatistics((TSimulation?) simulation);
+        }
+
+        // Highlights the selected map visualization button
+        protected void SelectVisualizationButton(Button selectedButton) {
+            foreach (var button in _mapVisualizationToggleGroup) 
+                button.image.color = _mapVisualizationColor;
+
+            selectedButton.image.color = _mapVisualizationSelectedColor;
         }
     }
 }


### PR DESCRIPTION
This PR allows
- To view the patrolling and coverage heat map.
- See which button has been selected in the patrolling UI.
- Change the name of the buttons since it was wrong typed before.

There is one bug: when selecting from Waypoint heat map to coverage heat map the Waypoint heat map is still viewed but not updated. Therefore when switching away from Waypoint heat map, the color of the waypoints should be standard color.
