### PR TITLE
Optimize raytracing

### DIFF
--- a/Assets/Scripts/CustomScriptsAssembly.asmdef
+++ b/Assets/Scripts/CustomScriptsAssembly.asmdef
@@ -14,7 +14,7 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Scripts/Map/SlamMap.cs
+++ b/Assets/Scripts/Map/SlamMap.cs
@@ -168,19 +168,12 @@ namespace Maes.Map
             var localCoordinate = TriangleIndexToCoordinate(triangleIndex);
             CurrentlyVisibleTriangles.Add(triangleIndex);
 
-            if (!CurrentlyVisibleTiles.ContainsKey(localCoordinate))
+            if (!CurrentlyVisibleTiles.ContainsKey(localCoordinate) || CurrentlyVisibleTiles[localCoordinate] != SlamTileStatus.Solid)
             {
                 var newStatus = isOpen ? SlamTileStatus.Open : SlamTileStatus.Solid;
                 CurrentlyVisibleTiles[localCoordinate] = newStatus;
                 CoarseMap.UpdateTile(CoarseMap.FromSlamMapCoordinate(localCoordinate), newStatus);
             }
-            else if (CurrentlyVisibleTiles[localCoordinate] != SlamTileStatus.Solid)
-            {
-                var newStatus = isOpen ? SlamTileStatus.Open : SlamTileStatus.Solid;
-                CurrentlyVisibleTiles[localCoordinate] = newStatus;
-                CoarseMap.UpdateTile(CoarseMap.FromSlamMapCoordinate(localCoordinate), newStatus);
-            }
-
         }
 
         public SlamTileStatus GetVisibleTileByTriangleIndex(int triangleIndex)

--- a/Assets/Scripts/Utilities/Functional.cs
+++ b/Assets/Scripts/Utilities/Functional.cs
@@ -19,6 +19,7 @@
 // 
 // Original repository: https://github.com/MalteZA/MAES
 
+using System;
 using System.Collections.Generic;
 
 namespace Maes.Utilities
@@ -29,7 +30,7 @@ namespace Maes.Utilities
 
         public delegate bool XBetterThanY<T>(T x, T y);
 
-        public static T TakeBest<T>(T[] values, XBetterThanY<T> xBetterThanY)
+        public static T TakeBest<T>(Span<T> values, XBetterThanY<T> xBetterThanY)
         {
             var currentMin = values[0];
             for (var i = 1; i < values.Length; i++)


### PR DESCRIPTION
Instead of using a list we use a stack allocated array. This is much faster as no allocations are needed as Vector2 and int are both "structs" aka stack allocated things.