### PR TITLE
Resetting Patrolling UI after change mode

### DIFF
--- a/Assets/Scripts/Statistics/PatrollingVisualizer.cs
+++ b/Assets/Scripts/Statistics/PatrollingVisualizer.cs
@@ -1,4 +1,3 @@
-
 using System.Collections.Generic;
 
 using Maes.Map;
@@ -60,6 +59,14 @@ namespace Maes.Statistics
             }
         }
 
+        public void ResetWaypointsColor()
+        {
+            foreach (var vertex in _patrollingMap.Vertices)
+            {
+                _vertexVisualizers[vertex].GetComponent<MeshRenderer>().material.color = vertex.Color;
+            }
+        }
+
         public void ShowWaypointHeatMap(int currentTick)
         {
 
@@ -81,6 +88,18 @@ namespace Maes.Statistics
         {
             var yellowColor = new Color(255, 255, 0, 255);
             _vertexVisualizers[targetVertex].GetComponent<MeshRenderer>().material.color = yellowColor;
+        }
+
+        public void ShowDefaultColor(Vertex vertex)
+        {
+            if (_vertexVisualizers.TryGetValue(vertex, out var vertexObject))
+            {
+                vertexObject.GetComponent<MeshRenderer>().material.color = vertex.Color;
+            }
+            else
+            {
+                Debug.LogError($"Vertex {vertex.Position} not found in visualizer");
+            }
         }
     }
 }

--- a/Assets/Scripts/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Trackers/PatrollingTracker.cs
@@ -60,6 +60,11 @@ namespace Maes.Trackers
 
             WorstGraphIdleness = Mathf.Max(WorstGraphIdleness, vertexDetails.MaxIdleness);
             SetCompletedCycles();
+
+            if (_currentVisualizationMode is PatrollingTargetWaypointVisualizationMode)
+            {
+                _visualizer.ShowDefaultColor(vertex);
+            }
         }
 
         protected override void OnLogicUpdate(IReadOnlyList<MonaRobot> robots)
@@ -107,6 +112,12 @@ namespace Maes.Trackers
             CompletedCycles = Vertices.Values.Select(v => v.NumberOfVisits).Min();
         }
 
+        protected override void SetVisualizationMode(IPatrollingVisualizationMode newMode)
+        {
+            _visualizer.ResetWaypointsColor();
+            base.SetVisualizationMode(newMode);
+        }
+
         public void ShowWaypointHeatMap()
         {
             _visualizer.meshRenderer.enabled = false;
@@ -127,6 +138,7 @@ namespace Maes.Trackers
 
         public void ShowTargetWaypointSelected()
         {
+            _visualizer.meshRenderer.enabled = false;
             if (_selectedRobot == null)
             {
                 throw new Exception("Cannot change to 'ShowTargetWaypointSelected' Visualization mode when no robot is selected");
@@ -137,6 +149,7 @@ namespace Maes.Trackers
 
         public void ShowVisibleSelected()
         {
+            _visualizer.meshRenderer.enabled = false;
             if (_selectedRobot == null)
             {
                 throw new Exception("Cannot change to 'ShowVisibleSelected' Visualization mode when no robot is selected");

--- a/Assets/Scripts/Trackers/Tracker.cs
+++ b/Assets/Scripts/Trackers/Tracker.cs
@@ -163,7 +163,7 @@ namespace Maes.Trackers
 
         protected virtual void AfterRayTracingARobot(MonaRobot robot) { }
 
-        protected void SetVisualizationMode(TVisualizationMode newMode)
+        protected virtual void SetVisualizationMode(TVisualizationMode newMode)
         {
             _currentVisualizationMode = newMode;
             _currentVisualizationMode.UpdateVisualization(_visualizer, _currentTick);


### PR DESCRIPTION
- Resets the Patrolling UI after change mode.
- When the robot reaches a vertex, and the visualisation mode is "target waypoint", it resets the target vertex to default color
