### PR TITLE
Optimize Visible Tiles

### DIFF
--- a/Assets/Scripts/ExplorationAlgorithm/Voronoi/VoronoiExplorationAlgorithm.cs
+++ b/Assets/Scripts/ExplorationAlgorithm/Voronoi/VoronoiExplorationAlgorithm.cs
@@ -266,9 +266,9 @@ namespace Maes.ExplorationAlgorithm.Voronoi
         private void UpdateExploredStatusOfTiles()
         {
             var currentPosition = _robotController.GetSlamMap().GetCoarseMap().GetApproximatePosition();
-            var currentlyVisibleTiles = _robotController.GetSlamMap().GetCurrentlyVisibleTiles();
+            var visibleTilesList = _robotController.GetSlamMap().GetVisibleTiles();
             var currentlyVisibleCoarseTiles = _robotController.GetSlamMap().GetCoarseMap()
-                .FromSlamMapCoordinates(currentlyVisibleTiles.Keys.ToList());
+                .FromSlamMapCoordinates(visibleTilesList);
 
             foreach (var visibleTile in currentlyVisibleCoarseTiles)
             {
@@ -496,8 +496,8 @@ namespace Maes.ExplorationAlgorithm.Voronoi
         private List<Vector2Int> FindClosestOcclusionPoints()
         {
             var coarseMap = _robotController.GetSlamMap().GetCoarseMap();
-            var visibleTilesMaps = _robotController.GetSlamMap().GetCurrentlyVisibleTiles();
-            var visibleCoarseTiles = coarseMap.FromSlamMapCoordinates(visibleTilesMaps.Keys).ToList();
+            var visibleTilesList = _robotController.GetSlamMap().GetVisibleTiles();
+            var visibleCoarseTiles = coarseMap.FromSlamMapCoordinates(visibleTilesList).ToList();
 
             var robotPosition = coarseMap.GetApproximatePosition();
 
@@ -690,8 +690,8 @@ namespace Maes.ExplorationAlgorithm.Voronoi
             var robotIdToClosestTilesMap = new Dictionary<int, List<Vector2Int>>();
 
             // Assign tiles to robots to create regions
-            var currentlyVisibleTiles = _robotController.GetSlamMap().GetCurrentlyVisibleTiles();
-            var currentlyVisibleCoarseTiles = coarseMap.FromSlamMapCoordinates(currentlyVisibleTiles.Keys.ToList()).ToHashSet();
+            var visibleTilesList = _robotController.GetSlamMap().GetVisibleTiles();
+            var currentlyVisibleCoarseTiles = coarseMap.FromSlamMapCoordinates(visibleTilesList).ToHashSet();
             for (var x = myPosition.x - _voronoiRegionMaxDistance; x < myPosition.x + _voronoiRegionMaxDistance; x++)
             {
                 for (var y = myPosition.y - _voronoiRegionMaxDistance; y < myPosition.y + _voronoiRegionMaxDistance; y++)

--- a/Assets/Scripts/Map/VisibleTilesCoarseMap.cs
+++ b/Assets/Scripts/Map/VisibleTilesCoarseMap.cs
@@ -66,7 +66,7 @@ namespace Maes.Map
             var slamTile = ToSlamMapCoordinate(coordinate);
 
             // Anything not currently visible is solid
-            if (_slamMap.CurrentlyVisibleTiles[slamTile] == SlamMap.SlamTileStatus.Unseen)
+            if (_slamMap.GetVisibleTileStatus(slamTile.x, slamTile.y) == SlamMap.SlamTileStatus.Unseen)
             {
                 return true;
             }
@@ -96,12 +96,7 @@ namespace Maes.Map
             var slamTile = ToSlamMapCoordinate(coordinate);
 
             // Anything not currently visible is not solid
-            if (!_slamMap.CurrentlyVisibleTiles.ContainsKey(slamTile))
-            {
-                return false;
-            }
-
-            if (_slamMap.CurrentlyVisibleTiles[slamTile] == SlamMap.SlamTileStatus.Unseen)
+            if (_slamMap.GetVisibleTileStatus(slamTile.x, slamTile.y) == SlamMap.SlamTileStatus.Unseen)
             {
                 return false;
             }

--- a/Assets/Scripts/Robot/ISlamAlgorithm.cs
+++ b/Assets/Scripts/Robot/ISlamAlgorithm.cs
@@ -45,12 +45,7 @@ namespace Maes.Robot
         /// If the key is not present in the dictionary the tile is not explored. </returns>
         public Dictionary<Vector2Int, SlamMap.SlamTileStatus> GetExploredTiles();
 
-        /// <summary>
-        /// The method returns all tiles that can currently be seen by the robot. Vision range is determined by
-        /// lidar range in <see cref="RobotConstraints"/> 
-        /// </summary>
-        /// <returns>a dictionary containing the tile status of all currently visible tiles</returns>
-        public Dictionary<Vector2Int, SlamMap.SlamTileStatus> GetCurrentlyVisibleTiles();
+        public SlamMap.SlamTileStatus GetVisibleTileStatus(int x, int y);
 
         /// <returns> The current position of the robot as a slam tile coordinate (rounded down) </returns>
         public Vector2Int GetCurrentPosition();

--- a/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -35,11 +35,6 @@
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "ShapeComponent.ResetSettings",
                 "value": "{\"m_Value\":false}"
-            },
-            {
-                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                "key": "editor.toolbarIconGUI",
-                "value": "{\"m_Value\":false}"
             }
         ]
     }


### PR DESCRIPTION
Before it was a dictionary that was constantly recreated causing memory allocations.
Now it is a fixed-size multi-dimensional array.

This completely removes it from the profiler.