### PR TITLE
Patrolling data to CSV

### DIFF
--- a/Assets/Scripts/Simulation/ExplorationSimulation.cs
+++ b/Assets/Scripts/Simulation/ExplorationSimulation.cs
@@ -40,7 +40,7 @@ namespace Maes.Simulation
             }
 
             var path = GlobalSettings.StatisticsOutPutPath + _scenario.StatisticsFileName + "_" + resultForFileName;
-            new ExplorationCsvDataWriter(this, path).CreateCsvFile(",");
+            new ExplorationCsvDataWriter(this, path).CreateCsvFile();
         }
     }
 }

--- a/Assets/Scripts/Simulation/PatrollingSimulation.cs
+++ b/Assets/Scripts/Simulation/PatrollingSimulation.cs
@@ -1,8 +1,14 @@
+using System;
+using System.Globalization;
+using System.IO;
+
 using Maes.Algorithms;
 using Maes.Map.MapPatrollingGen;
 using Maes.Map.RobotSpawners;
 using Maes.Simulation.SimulationScenarios;
 using Maes.Statistics;
+using Maes.Statistics.Patrolling;
+using Maes.Statistics.Writer;
 using Maes.Trackers;
 using Maes.UI.SimulationInfoUIControllers;
 
@@ -23,7 +29,7 @@ namespace Maes.Simulation
         {
             var patrollingMap = scenario.PatrollingMapFactory(new PatrollingMapSpawner(), _collisionMap);
 
-            PatrollingTracker = new PatrollingTracker(_collisionMap, patrollingVisualizer, this, scenario, patrollingMap);
+            PatrollingTracker = new PatrollingTracker(_collisionMap, patrollingVisualizer, scenario, patrollingMap);
 
             patrollingVisualizer.SetPatrollingMap(patrollingMap);
 
@@ -43,6 +49,21 @@ namespace Maes.Simulation
             }
 
             return PatrollingTracker.AverageGraphDiffLastTwoCyclesProportion <= 0.025;
+        }
+
+        protected override void CreateStatisticsFile()
+        {
+            var folderPath = GlobalSettings.StatisticsOutPutPath + _scenario.StatisticsFileName + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
+            Directory.CreateDirectory(folderPath);
+
+            var patrollingFilename = Path.Join(folderPath, "patrolling");
+            new PatrollingCsvDataWriter(this, patrollingFilename).CreateCsvFile();
+
+            foreach (var (point, snapShots) in PatrollingTracker.WaypointSnapShots)
+            {
+                var waypointFilename = Path.Join(folderPath, $"waypoint_{point.x}_{point.y}");
+                new CsvDataWriter<WaypointSnapShot>(snapShots, waypointFilename).CreateCsvFileNoPrepare();
+            }
         }
     }
 }

--- a/Assets/Scripts/Statistics/Communication.meta
+++ b/Assets/Scripts/Statistics/Communication.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6f01dda183b143779267badb17aa6234
+timeCreated: 1731664486

--- a/Assets/Scripts/Statistics/Communication/CommunicationCsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Communication/CommunicationCsvDataWriter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+using Maes.Robot;
+using Maes.Statistics.Writer;
+using Maes.Utilities;
+
+namespace Maes.Statistics.Communication
+{
+    public class CommunicationCsvDataWriter<TSnapShot> : CsvDataWriter<TSnapShot>
+    where TSnapShot : CommunicationSnapShot
+    {
+        private readonly Dictionary<int, bool> _allAgentsConnectedSnapShots;
+        private readonly Dictionary<int, float> _biggestClusterPercentageSnapShots;
+
+        public CommunicationCsvDataWriter(CommunicationManager communicationManager, List<TSnapShot> snapShots, string filename) : base(snapShots, filename)
+        {
+            _allAgentsConnectedSnapShots = communicationManager.CommunicationTracker.InterconnectionSnapShot;
+            _biggestClusterPercentageSnapShots = communicationManager.CommunicationTracker.BiggestClusterPercentageSnapshots;
+        }
+
+        protected override void PrepareSnapShot(TSnapShot snapShot)
+        {
+            snapShot.AgentsInterconnected = _allAgentsConnectedSnapShots.GetValueOrNull(snapShot.Tick);
+            snapShot.BiggestClusterPercentage = _biggestClusterPercentageSnapShots.GetValueOrNull(snapShot.Tick);
+        }
+    }
+}

--- a/Assets/Scripts/Statistics/Communication/CommunicationCsvDataWriter.cs.meta
+++ b/Assets/Scripts/Statistics/Communication/CommunicationCsvDataWriter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c8b3c72f1b1445bd94f4af86ccfeb500
+timeCreated: 1731664939

--- a/Assets/Scripts/Statistics/Communication/CommunicationSnapShot.cs
+++ b/Assets/Scripts/Statistics/Communication/CommunicationSnapShot.cs
@@ -1,0 +1,24 @@
+using CsvHelper.Configuration.Attributes;
+
+using Maes.Statistics.Writer.TypeConverter;
+
+namespace Maes.Statistics.Communication
+{
+    public class CommunicationSnapShot
+    {
+        [Index(0)]
+        public int Tick { get; }
+
+        [Name("Agents Interconnected"), TypeConverter(typeof(BooleanNullableToBinaryConverter))]
+        public bool? AgentsInterconnected { get; set; }
+        [Name("Biggest Cluster %"), TypeConverter(typeof(NullableFloatToStringConverter))]
+        public float? BiggestClusterPercentage { get; set; }
+
+        public CommunicationSnapShot(int tick, bool? agentsInterconnected = null, float? biggestClusterPercentage = null)
+        {
+            Tick = tick;
+            AgentsInterconnected = agentsInterconnected;
+            BiggestClusterPercentage = biggestClusterPercentage;
+        }
+    }
+}

--- a/Assets/Scripts/Statistics/Communication/CommunicationSnapShot.cs.meta
+++ b/Assets/Scripts/Statistics/Communication/CommunicationSnapShot.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 153f875c0e4e4aceae0e25e8dcc2f7e7
+timeCreated: 1731664503

--- a/Assets/Scripts/Statistics/Exploration/ExplorationCsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Exploration/ExplorationCsvDataWriter.cs
@@ -1,26 +1,10 @@
-using System.Collections.Generic;
-
 using Maes.Simulation;
-using Maes.Statistics.Writer;
-using Maes.Utilities;
+using Maes.Statistics.Communication;
 
 namespace Maes.Statistics.Exploration
 {
-    public class ExplorationCsvDataWriter : CsvDataWriter<ExplorationSnapShot>
+    public class ExplorationCsvDataWriter : CommunicationCsvDataWriter<ExplorationSnapShot>
     {
-        private readonly Dictionary<int, bool> _allAgentsConnectedSnapShots;
-        private readonly Dictionary<int, float> _biggestClusterPercentageSnapShots;
-
-        public ExplorationCsvDataWriter(ExplorationSimulation simulation, string filename) : base(simulation.ExplorationTracker.snapShots, filename)
-        {
-            _allAgentsConnectedSnapShots = simulation.CommunicationManager.CommunicationTracker.InterconnectionSnapShot;
-            _biggestClusterPercentageSnapShots = simulation.CommunicationManager.CommunicationTracker.BiggestClusterPercentageSnapshots;
-        }
-
-        protected override void PrepareSnapShot(ExplorationSnapShot snapShot)
-        {
-            snapShot.AgentsInterconnected = _allAgentsConnectedSnapShots.GetValueOrNull(snapShot.Tick);
-            snapShot.BiggestClusterPercentage = _biggestClusterPercentageSnapShots.GetValueOrNull(snapShot.Tick);
-        }
+        public ExplorationCsvDataWriter(ExplorationSimulation simulation, string filename) : base(simulation.CommunicationManager, simulation.ExplorationTracker.snapShots, filename) { }
     }
 }

--- a/Assets/Scripts/Statistics/Exploration/ExplorationSnapShot.cs
+++ b/Assets/Scripts/Statistics/Exploration/ExplorationSnapShot.cs
@@ -1,51 +1,23 @@
-using CsvHelper.Configuration;
 using CsvHelper.Configuration.Attributes;
 
-using Maes.Statistics.Writer.TypeConverter;
+using Maes.Statistics.Communication;
 
 namespace Maes.Statistics.Exploration
 {
-    public class ExplorationSnapShot
+    public class ExplorationSnapShot : CommunicationSnapShot
     {
-        public int Tick { get; }
+        [Index(1)]
         public float Explored { get; }
+        [Index(2)]
         public float Covered { get; }
-        [Name("Average Agent Distance")]
+        [Name("Average Agent Distance"), Index(3)]
         public float AverageAgentDistance { get; }
-        [Name("Agents Interconnected"), TypeConverter(typeof(BooleanNullableToBinaryConverter))]
-        public bool? AgentsInterconnected { get; set; }
-        [Name("Biggest Cluster %"), TypeConverter(typeof(NullableFloatToStringConverter))]
-        public float? BiggestClusterPercentage { get; set; }
 
-        public ExplorationSnapShot(int tick, float explored, float covered, float averageAgentDistance, bool? agentsInterconnected = null, float? biggestClusterPercentage = null)
+        public ExplorationSnapShot(int tick, float explored, float covered, float averageAgentDistance, bool? agentsInterconnected = null, float? biggestClusterPercentage = null) : base(tick, agentsInterconnected, biggestClusterPercentage)
         {
-            Tick = tick;
             Explored = explored;
             Covered = covered;
             AverageAgentDistance = averageAgentDistance;
-            AgentsInterconnected = agentsInterconnected;
-            BiggestClusterPercentage = biggestClusterPercentage;
-        }
-    }
-
-    public sealed class ExplorationSnapShotMap : ClassMap<ExplorationSnapShot>
-    {
-        public ExplorationSnapShotMap()
-        {
-            Map(e => e.Tick).Index(0).Name("Tick");
-            Map(e => e.Explored).Index(1).Name("Explored");
-            Map(e => e.Covered).Index(2).Name("Covered");
-            Map(e => e.AverageAgentDistance).Index(3).Name("Average Agent Distance");
-
-            Map(e => e.AgentsInterconnected)
-                .Index(4)
-                .TypeConverter<BooleanNullableToBinaryConverter>()
-                .Name("Agents Interconnected");
-
-            Map(e => e.BiggestClusterPercentage)
-                .Index(5)
-                .TypeConverter<NullableFloatToStringConverter>()
-                .Name("Biggest Cluster %");
         }
     }
 }

--- a/Assets/Scripts/Statistics/Patrolling.meta
+++ b/Assets/Scripts/Statistics/Patrolling.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f372b48c4dd048b28e81b985e20c1786
+timeCreated: 1731663972

--- a/Assets/Scripts/Statistics/Patrolling/PatrollingCsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Patrolling/PatrollingCsvDataWriter.cs
@@ -1,0 +1,12 @@
+using Maes.Simulation;
+using Maes.Statistics.Communication;
+
+namespace Maes.Statistics.Patrolling
+{
+    public class PatrollingCsvDataWriter : CommunicationCsvDataWriter<PatrollingSnapShot>
+    {
+        public PatrollingCsvDataWriter(PatrollingSimulation simulation, string filename) : base(simulation.CommunicationManager, simulation.PatrollingTracker.SnapShots, filename)
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Statistics/Patrolling/PatrollingCsvDataWriter.cs.meta
+++ b/Assets/Scripts/Statistics/Patrolling/PatrollingCsvDataWriter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7c2467b8334e4ef6b8ea2d070be88c17
+timeCreated: 1731663987

--- a/Assets/Scripts/Statistics/Patrolling/PatrollingSnapShot.cs
+++ b/Assets/Scripts/Statistics/Patrolling/PatrollingSnapShot.cs
@@ -1,0 +1,28 @@
+using CsvHelper.Configuration.Attributes;
+
+using Maes.Statistics.Communication;
+
+namespace Maes.Statistics.Patrolling
+{
+    public class PatrollingSnapShot : CommunicationSnapShot
+    {
+        [Index(1)]
+        public float GraphIdleness { get; }
+        [Index(2)]
+        public int WorstGraphIdleness { get; }
+        [Index(3)]
+        public float TotalDistanceTraveled { get; }
+        [Index(4)]
+        public int CompletedCycles { get; }
+
+        public PatrollingSnapShot(int tick, float graphIdleness, int worstGraphIdleness, float totalDistanceTraveled,
+            int completedCycles, bool? agentsInterconnected = null, float? biggestClusterPercentage = null) : base(tick,
+            agentsInterconnected, biggestClusterPercentage)
+        {
+            GraphIdleness = graphIdleness;
+            WorstGraphIdleness = worstGraphIdleness;
+            TotalDistanceTraveled = totalDistanceTraveled;
+            CompletedCycles = completedCycles;
+        }
+    }
+}

--- a/Assets/Scripts/Statistics/Patrolling/PatrollingSnapShot.cs.meta
+++ b/Assets/Scripts/Statistics/Patrolling/PatrollingSnapShot.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4c1b2d213241486f8028f1de9cba4b3e
+timeCreated: 1731664321

--- a/Assets/Scripts/Statistics/Patrolling/WaypointSnapShot.cs
+++ b/Assets/Scripts/Statistics/Patrolling/WaypointSnapShot.cs
@@ -1,0 +1,19 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace Maes.Statistics.Patrolling
+{
+    public class WaypointSnapShot
+    {
+        public int Tick { get; }
+        public int Idleness { get; }
+        [Name("Number of visit")]
+        public int NumberOfVisit { get; }
+
+        public WaypointSnapShot(int tick, int idleness, int numberOfVisit)
+        {
+            Tick = tick;
+            Idleness = idleness;
+            NumberOfVisit = numberOfVisit;
+        }
+    }
+}

--- a/Assets/Scripts/Statistics/Patrolling/WaypointSnapShot.cs.meta
+++ b/Assets/Scripts/Statistics/Patrolling/WaypointSnapShot.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 71598c3201b1479f8676dbb741f88cee
+timeCreated: 1731665803

--- a/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
@@ -9,18 +9,18 @@ using UnityEngine;
 
 namespace Maes.Statistics.Writer
 {
-    public abstract class CsvDataWriter<TSnapShot>
+    public class CsvDataWriter<TSnapShot>
     {
         private readonly List<TSnapShot> _snapShots;
         private readonly string _path;
 
-        protected CsvDataWriter(List<TSnapShot> snapShots, string filename)
+        public CsvDataWriter(List<TSnapShot> snapShots, string filename)
         {
             _snapShots = snapShots;
             _path = filename + ".csv";
         }
 
-        public void CreateCsvFile(string separator)
+        public void CreateCsvFile(string separator = ",")
         {
             using var writer = new StreamWriter(Path.GetFullPath(_path));
             using var csv = new CsvWriter(writer, new CsvConfiguration(CultureInfo.InvariantCulture)
@@ -36,6 +36,19 @@ namespace Maes.Statistics.Writer
                 csv.WriteRecord(snapShot);
                 csv.NextRecord();
             }
+            Debug.Log($"Writing statistics to path: {_path}");
+        }
+
+        public void CreateCsvFileNoPrepare(string separator = ",")
+        {
+            using var writer = new StreamWriter(Path.GetFullPath(_path));
+            using var csv = new CsvWriter(writer, new CsvConfiguration(CultureInfo.InvariantCulture)
+            {
+                Delimiter = separator
+            });
+
+            csv.WriteRecords(_snapShots);
+
             Debug.Log($"Writing statistics to path: {_path}");
         }
 

--- a/Assets/Scripts/Trackers/Tracker.cs
+++ b/Assets/Scripts/Trackers/Tracker.cs
@@ -81,7 +81,6 @@ namespace Maes.Trackers
             OnLogicUpdate(robots);
 
             _currentVisualizationMode.UpdateVisualization(_visualizer, _currentTick);
-            _currentTick++;
 
             if (GlobalSettings.ShouldWriteCsvResults
                 && _currentTick != 0
@@ -89,6 +88,7 @@ namespace Maes.Trackers
             {
                 CreateSnapShot();
             }
+            _currentTick++;
         }
 
         protected virtual void OnLogicUpdate(IReadOnlyList<MonaRobot> robots) { }


### PR DESCRIPTION
Logs the patrolling raw data to a CSV files.

It make a folder, that contains a CSV file called `patrolling.csv` and the a CSV file for each waypoints.
<img width="692" alt="Screenshot 2024-11-15 at 14 18 33" src="https://github.com/user-attachments/assets/7b6e8b23-d812-416b-81d5-8057c46e56fb">

The `patrolling.csv` contains: Tick, Graph Idleness,  Current Worst Idleness, Distance Traveled, CompletedCycles, Agents Interconnected, Biggest Cluster %
<img width="770" alt="Screenshot 2024-11-15 at 14 17 58" src="https://github.com/user-attachments/assets/bf7f0835-4bd2-4ea5-8f2f-b601a3999d05">

Each waypoint files contains: Tick, Idleness, Number of visit.
<img width="206" alt="Screenshot 2024-11-15 at 14 18 09" src="https://github.com/user-attachments/assets/3b5178ff-d8de-46b1-8c4c-023ab44c0171">

Agents Interconnected, Biggest Cluster % is logged in both patrolling and exploration, and therefore `PatrollingSnapShot` and `ExplorationSnapShot` inherit from the `CommunicationSnapShot`, and a CsvDataWriter is implemented for `CommunicationSnapShot` that is used for both patrolling and exploration