### PR TITLE
Fix vertex cloning

### DIFF
--- a/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
@@ -2,12 +2,16 @@ using Maes.Map;
 
 namespace Maes.Algorithms
 {
-    public delegate void OnReachVertex(Vertex vertex, int atTick);
+    public delegate void OnReachVertex(int vertexId, int atTick);
+
     public interface IPatrollingAlgorithm : IAlgorithm
     {
         string AlgorithmName { get; }
+
         Vertex TargetVertex { get; }
+
         void SetPatrollingMap(PatrollingMap map);
+
         void SubscribeOnReachVertex(OnReachVertex onReachVertex);
     }
 }

--- a/Assets/Scripts/Map/MapPatrollingGen/PatrollingMapRectangleGen.cs
+++ b/Assets/Scripts/Map/MapPatrollingGen/PatrollingMapRectangleGen.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,7 +8,7 @@ using UnityEngine;
 
 namespace Maes.Map.MapPatrollingGen
 {
-    public class PatrollingMapRectangleGen
+    public static class PatrollingMapRectangleGen
     {
         public static PatrollingMap Generate(SimulationMap<Tile> simulationMap)
         {
@@ -28,53 +29,56 @@ namespace Maes.Map.MapPatrollingGen
                 }
             }
 
-            var verticies = CreateVerticiesFromRooms(new SplitRoom(roomTiles.ToArray(), "Start"));
+            var vertices = CreateVerticesFromRooms(new SplitRoom(roomTiles.ToArray(), "Start"));
 
-            return new PatrollingMap(verticies);
+            return new PatrollingMap(vertices);
         }
 
-        private static Vertex[] CreateVerticiesFromRooms(SplitRoom splitRoom)
+        private static Vertex[] CreateVerticesFromRooms(SplitRoom splitRoom)
         {
-            var roomVerticies = new Dictionary<SplitRoom, Vertex>();
+            var roomVertices = new Dictionary<SplitRoom, Vertex>();
             var splitRooms = SplitTheRoomToPieces(splitRoom);
 
             // Create a vertex for each room
-            foreach (var room in splitRooms)
+            for (var i = 0; i < splitRooms.Length; i++)
             {
+                var room = splitRooms[i];
                 var centerPoint = GetCenterPointOfRoom(room);
-                var vertex = new Vertex(1.0f, centerPoint);
-                roomVerticies.Add(room, vertex);
+                var vertex = new Vertex(i, 1.0f, centerPoint);
+                roomVertices.Add(room, vertex);
             }
 
+            var roomVerticesArray = roomVertices.ToArray();
+
             // Connect rooms with each other
-            foreach (var (room, vertex) in roomVerticies)
+            for (var i = 0; i < roomVerticesArray.Length; i++)
             {
-                foreach (var (otherRoom, otherVertex) in roomVerticies)
+                var (room, vertex) = roomVerticesArray[i];
+                for (var j = i + 1; j < roomVerticesArray.Length; j++)
                 {
-                    if (room == otherRoom)
-                    {
-                        continue;
-                    }
+                    var (otherRoom, otherVertex) = roomVerticesArray[j];
 
                     if (DoRoomsConnect(room, otherRoom))
                     {
                         vertex.AddNeighbor(otherVertex);
+                        otherVertex.AddNeighbor(vertex);
                     }
-
+#if DEBUG
                     if (DoRoomsOverlap(room, otherRoom))
                     {
                         Debug.LogError($"Room {room.FromWhichAlgo} overlaps with Room {otherRoom.FromWhichAlgo}");
                     }
+#endif
                 }
             }
 
             // Visualize all tiles
-            // return roomVerticies.Keys
+            // return roomVertices.Keys
             //     .Select(r => (Random.ColorHSV(0.2f, 1.0f), r))
             //     .SelectMany(p => p.r.Tiles.Select(t => new Vertex(1.0f, t, p.Item1)))
             //     .ToArray();
 
-            return roomVerticies.Values.ToArray();
+            return roomVertices.Values.ToArray();
         }
 
         private static Vector2Int GetCenterPointOfRoom(SplitRoom room)
@@ -112,7 +116,7 @@ namespace Maes.Map.MapPatrollingGen
                 }
 
                 SplitTheRoomRecursive(leftRoom);
-                SplitTheRoomRecursive(rightRoom);
+                SplitTheRoomRecursive(rightRoom.Value);
             }
         }
 
@@ -183,7 +187,7 @@ namespace Maes.Map.MapPatrollingGen
             foreach (var tile in splitRoom.Tiles)
             {
                 // If no tiles are on the right side add it as potential split
-                if (!splitRoom.Tiles.Any(t => t == tile + Vector2Int.right))
+                if (splitRoom.Tiles.All(t => t != tile + Vector2Int.right))
                 {
                     potentialSplits.Add(tile.x);
                 }
@@ -212,7 +216,7 @@ namespace Maes.Map.MapPatrollingGen
             var potentialSplits = new HashSet<int>();
             foreach (var tile in splitRoom.Tiles)
             {
-                if (!splitRoom.Tiles.Any(t => t == tile + Vector2Int.left))
+                if (splitRoom.Tiles.All(t => t != tile + Vector2Int.left))
                 {
                     potentialSplits.Add(tile.x);
                 }
@@ -238,7 +242,7 @@ namespace Maes.Map.MapPatrollingGen
 
             foreach (var tile in splitRoom.Tiles)
             {
-                if (!splitRoom.Tiles.Any(t => t == tile + Vector2Int.up))
+                if (splitRoom.Tiles.All(t => t != tile + Vector2Int.up))
                 {
                     potentialSplits.Add(tile.y);
                 }
@@ -270,9 +274,9 @@ namespace Maes.Map.MapPatrollingGen
             return first.Tiles.Any(f => second.Tiles.Any(s => f == s));
         }
 
-        private class SplitRoom
+        private readonly struct SplitRoom : IEquatable<SplitRoom>
         {
-            public readonly IReadOnlyCollection<Vector2Int> Tiles;
+            public readonly Vector2Int[] Tiles;
 
             public readonly string FromWhichAlgo;
 
@@ -280,6 +284,31 @@ namespace Maes.Map.MapPatrollingGen
             {
                 Tiles = tiles;
                 FromWhichAlgo = algo;
+            }
+
+            public bool Equals(SplitRoom other)
+            {
+                return Tiles.Equals(other.Tiles) && FromWhichAlgo == other.FromWhichAlgo;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is SplitRoom other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Tiles, FromWhichAlgo);
+            }
+
+            public static bool operator ==(SplitRoom left, SplitRoom right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(SplitRoom left, SplitRoom right)
+            {
+                return !left.Equals(right);
             }
         }
     }

--- a/Assets/Scripts/Map/MapPatrollingGen/PatrollingWaypointGenerator.cs
+++ b/Assets/Scripts/Map/MapPatrollingGen/PatrollingWaypointGenerator.cs
@@ -31,10 +31,11 @@ namespace Maes.Map.MapPatrollingGen
             }
 
             var delaunator = new Delaunator(points.ToArray());
-            foreach (var triangle in delaunator.Triangles)
+            for (var i = 0; i < delaunator.Triangles.Length; i++)
             {
+                var triangle = delaunator.Triangles[i];
                 var centerpoint = delaunator.GetCentroid(triangle);
-                centerCoordinatePoints.Add(new Vertex(0, new Vector2Int((int)centerpoint.X, (int)centerpoint.Y)));
+                centerCoordinatePoints.Add(new Vertex(i, 0, new Vector2Int((int)centerpoint.X, (int)centerpoint.Y)));
             }
 
             //TODO: Connect neighboring centerpoints with edges, currently only the centerpoints are generated

--- a/Assets/Scripts/Map/PatrollingMap.cs
+++ b/Assets/Scripts/Map/PatrollingMap.cs
@@ -1,25 +1,42 @@
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Maes.Utilities;
+
 namespace Maes.Map
 {
-    public class PatrollingMap : ICloneable
+    public class PatrollingMap : ICloneable<PatrollingMap>
     {
-        public readonly IReadOnlyList<Vertex> Vertices;
+        public readonly Vertex[] Vertices;
 
         //TODO: Add a better way to debug point generation, its is currently outcommented
         // public IReadOnlyList<Vertex> DebugPoints { get; set; }
 
-        public PatrollingMap(IEnumerable<Vertex> vertices)
+        public PatrollingMap(Vertex[] vertices)
         {
-            Vertices = vertices.ToList();
+            Vertices = vertices;
         }
 
-        public object Clone()
+        public PatrollingMap Clone()
         {
-            return new PatrollingMap(Vertices.Select(v => (Vertex)v.Clone()).ToArray());
+            var originalToCloned = new Dictionary<Vertex, Vertex>();
+            foreach (var originalVertex in Vertices)
+            {
+                var clonedVertex = new Vertex(originalVertex.Id, originalVertex.Weight, originalVertex.Position, originalVertex.Color);
+                originalToCloned.Add(originalVertex, clonedVertex);
+            }
+
+            foreach (var (originalVertex, clonedVertex) in originalToCloned)
+            {
+                foreach (var originalVertexNeighbor in originalVertex.Neighbors)
+                {
+                    var clonedVertexNeighbor = originalToCloned[originalVertexNeighbor];
+                    clonedVertex.AddNeighbor(clonedVertexNeighbor);
+                }
+            }
+
+            return new PatrollingMap(originalToCloned.Values.ToArray());
         }
     }
 }

--- a/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
+++ b/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
@@ -22,7 +22,7 @@ namespace Maes.Map.RobotSpawners
         {
             var robot = base.CreateRobot(x, y, relativeSize, robotId, algorithm, collisionMap, seed);
 
-            algorithm.SetPatrollingMap((PatrollingMap)_patrollingMap.Clone());
+            algorithm.SetPatrollingMap(_patrollingMap.Clone());
             algorithm.SubscribeOnReachVertex(_tracker.OnReachedVertex);
 
             return robot;

--- a/Assets/Scripts/Map/Vertex.cs
+++ b/Assets/Scripts/Map/Vertex.cs
@@ -6,20 +6,26 @@ using UnityEngine;
 
 namespace Maes.Map
 {
-    public class Vertex : ICloneable
+    public class Vertex
     {
-        private readonly HashSet<Vertex> _neighbors = new();
+        private readonly HashSet<Vertex> _neighbors;
+        public int Id { get; }
         public float Weight { get; }
         public int LastTimeVisitedTick { get; private set; }
         public Vector2Int Position { get; }
         public Color Color { get; }
         public int NumberOfVisits { get; private set; }
 
-        public Vertex(float weight, Vector2Int position, Color? color = null)
+        public Vertex(int id, float weight, Vector2Int position, Color? color = null)
         {
+            Id = id;
             Weight = weight;
             Position = position;
             Color = color ?? Color.green;
+            LastTimeVisitedTick = 0;
+            NumberOfVisits = 0;
+
+            _neighbors = new();
         }
 
         public IReadOnlyCollection<Vertex> Neighbors => _neighbors;
@@ -32,26 +38,19 @@ namespace Maes.Map
 
         public void AddNeighbor(Vertex neighbor)
         {
-            if (!Equals(neighbor, this))
+#if DEBUG
+            if (Equals(neighbor))
             {
-                _neighbors.Add(neighbor);
+                throw new InvalidOperationException("Cannot add self as neighbor");
             }
+#endif
+
+            _neighbors.Add(neighbor);
         }
 
         public void RemoveNeighbor(Vertex neighbor)
         {
             _neighbors.Remove(neighbor);
-        }
-
-        public object Clone()
-        {
-            var vertex = new Vertex(Weight, Position, Color);
-            foreach (var neighbor in _neighbors)
-            {
-                vertex.AddNeighbor(neighbor);
-            }
-
-            return vertex;
         }
     }
 }

--- a/Assets/Scripts/Map/Visualization/Patrolling/PatrollingTargetWaypointVisualizationMode.cs
+++ b/Assets/Scripts/Map/Visualization/Patrolling/PatrollingTargetWaypointVisualizationMode.cs
@@ -16,10 +16,6 @@ namespace Maes.Map.Visualization.Patrolling
         {
             var algorithm = (PatrollingAlgorithm)_robot.Algorithm;
             var targetWaypoint = algorithm.TargetVertex;
-            if (targetWaypoint == null)
-            {
-                return;
-            }
 
             visualizer.ShowTargetWaypoint(targetWaypoint);
         }

--- a/Assets/Scripts/PatrollingAlgorithms/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/ConscientiousReactiveAlgorithm.cs
@@ -1,57 +1,16 @@
-using System;
 using System.Linq;
 
 using Maes.Map;
-
-using UnityEngine;
 
 namespace Maes.PatrollingAlgorithms
 {
     public class ConscientiousReactiveAlgorithm : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Conscientious Reactive Algorithm";
-        private bool _isPatrolling;
-
-        public override string GetDebugInfo()
-        {
-            return
-                base.GetDebugInfo() +
-                $"Init done:  {_isPatrolling}\n";
-        }
-
-
-        protected override void Preliminaries()
-        {
-            if (_isPatrolling)
-            {
-                return;
-            }
-
-            var vertex = GetClosestVertex();
-            TargetVertex = vertex;
-            _isPatrolling = true;
-        }
 
         protected override Vertex NextVertex()
         {
-            return TargetVertex.Neighbors.OrderBy((x) => x.LastTimeVisitedTick).First();
-        }
-
-        private Vertex GetClosestVertex()
-        {
-            Vertex? closestVertex = null;
-            var closestDistance = float.MaxValue;
-            var position = _controller.GetSlamMap().GetCoarseMap().GetCurrentPosition();
-            foreach (var vertex in _vertices)
-            {
-                var distance = Vector2Int.Distance(position, vertex.Position);
-                if (distance < closestDistance)
-                {
-                    closestDistance = distance;
-                    closestVertex = vertex;
-                }
-            }
-            return closestVertex ?? throw new InvalidOperationException("There are no vertices!");
+            return TargetVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
         }
     }
 }

--- a/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
@@ -1,60 +1,19 @@
-using System;
 using System.Linq;
 
 using Maes.Map;
 
-using UnityEngine;
-
-/// <summary>
-/// The random reactive patrolling algorithm from "Multi-Agent Movement Coordination in Patrolling", 2002
-/// </summary>
 namespace Maes.PatrollingAlgorithms
 {
+    /// <summary>
+    /// The random reactive patrolling algorithm from "Multi-Agent Movement Coordination in Patrolling", 2002
+    /// </summary>
     public class RandomReactive : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Random Reactive Algorithm";
-        private bool _isPatrolling;
-
-        public override string GetDebugInfo()
-        {
-            return
-                base.GetDebugInfo() +
-                $"Init done:  {_isPatrolling}\n";
-        }
-
-
-        protected override void Preliminaries()
-        {
-            if (_isPatrolling)
-            {
-                return;
-            }
-
-            var vertex = GetClosestVertex();
-            TargetVertex = vertex;
-            _isPatrolling = true;
-        }
 
         protected override Vertex NextVertex()
         {
             return TargetVertex.Neighbors.ElementAt(UnityEngine.Random.Range(0, TargetVertex.Neighbors.Count));
-        }
-
-        private Vertex GetClosestVertex()
-        {
-            Vertex? closestVertex = null;
-            var closestDistance = float.MaxValue;
-            var position = _controller.GetSlamMap().GetCoarseMap().GetCurrentPosition();
-            foreach (var vertex in _vertices)
-            {
-                var distance = Vector2Int.Distance(position, vertex.Position);
-                if (distance < closestDistance)
-                {
-                    closestDistance = distance;
-                    closestVertex = vertex;
-                }
-            }
-            return closestVertex ?? throw new InvalidOperationException("There are no vertices!");
         }
     }
 }

--- a/Assets/Scripts/Statistics/PatrollingVisualizer.cs
+++ b/Assets/Scripts/Statistics/PatrollingVisualizer.cs
@@ -17,7 +17,7 @@ namespace Maes.Statistics
 
         private readonly List<GameObject> _visualizers = new();
 
-        private readonly Dictionary<Vertex, GameObject> _vertexVisualizers = new();
+        private readonly Dictionary<int, GameObject> _vertexVisualizers = new();
 
         public override void SetSimulationMap(SimulationMap<PatrollingCell> simulationMap, Vector3 offset)
         {
@@ -44,7 +44,7 @@ namespace Maes.Statistics
                 var meshRenderer = vertexVisualizer.GetComponent<MeshRenderer>();
                 meshRenderer.material.color = vertex.Color;
                 _visualizers.Add(vertexVisualizer);
-                _vertexVisualizers.Add(vertex, vertexVisualizer);
+                _vertexVisualizers.Add(vertex.Id, vertexVisualizer);
 
                 foreach (var otherVertex in vertex.Neighbors)
                 {
@@ -77,7 +77,7 @@ namespace Maes.Statistics
         {
             foreach (var vertex in _patrollingMap.Vertices)
             {
-                _vertexVisualizers[vertex].GetComponent<MeshRenderer>().material.color = vertex.Color;
+                _vertexVisualizers[vertex.Id].GetComponent<MeshRenderer>().material.color = vertex.Color;
             }
         }
 
@@ -94,19 +94,19 @@ namespace Maes.Statistics
                 var ticksSinceLastExplored = currentTick - vertex.LastTimeVisitedTick;
                 var coldness = Mathf.Min((float)ticksSinceLastExplored / (float)GlobalSettings.TicksBeforeWaypointCoverageHeatMapCold, 1.0f);
                 var color = Color32.Lerp(ExplorationVisualizer.WarmColor, ExplorationVisualizer.ColdColor, coldness);
-                _vertexVisualizers[vertex].GetComponent<MeshRenderer>().material.color = color;
+                _vertexVisualizers[vertex.Id].GetComponent<MeshRenderer>().material.color = color;
             }
         }
 
         public void ShowTargetWaypoint(Vertex targetVertex)
         {
             var yellowColor = new Color(255, 255, 0, 255);
-            _vertexVisualizers[targetVertex].GetComponent<MeshRenderer>().material.color = yellowColor;
+            _vertexVisualizers[targetVertex.Id].GetComponent<MeshRenderer>().material.color = yellowColor;
         }
 
         public void ShowDefaultColor(Vertex vertex)
         {
-            if (_vertexVisualizers.TryGetValue(vertex, out var vertexObject))
+            if (_vertexVisualizers.TryGetValue(vertex.Id, out var vertexObject))
             {
                 vertexObject.GetComponent<MeshRenderer>().material.color = vertex.Color;
             }

--- a/Assets/Scripts/Trackers/VertexDetails.cs
+++ b/Assets/Scripts/Trackers/VertexDetails.cs
@@ -1,17 +1,17 @@
 using Maes.Map;
 
-using UnityEngine;
-
 namespace Maes.Trackers
 {
-    public class VertexDetails : Vertex
+    public class VertexDetails
     {
         public int MaxIdleness { get; set; } = 0;
 
-        public VertexDetails(float weight, Vector2Int position, Color? color = null) : base(weight, position, color)
-        {
-        }
+        public Vertex Vertex { get; }
 
-        public VertexDetails(Vertex vertex) : base(vertex.Weight, vertex.Position, vertex.Color) { }
+
+        public VertexDetails(Vertex vertex)
+        {
+            Vertex = vertex;
+        }
     }
 }

--- a/Assets/Scripts/Utilities/ICloneable.cs
+++ b/Assets/Scripts/Utilities/ICloneable.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Maes.Utilities
+{
+    public interface ICloneable<T> : ICloneable
+        where T : notnull
+    {
+        new T Clone();
+        object ICloneable.Clone()
+        {
+            return Clone();
+        }
+    }
+}

--- a/Assets/Scripts/Utilities/ICloneable.cs.meta
+++ b/Assets/Scripts/Utilities/ICloneable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 31cf6235642347d9a395fbdd663ab942
+timeCreated: 1731678751


### PR DESCRIPTION
Before when we cloned a vertex we kept all neighbors as the original references to the original vertices. This was broken as after the robot visited the first vertex it would go on to the global vertices and thus share knowledge with other robots.

Now we clone a whole PatrollingMap. This makes it so that we can clone all vertices in the map, changing the references to the neighbors to the cloned vertices.

This uncovered some bugs that depended on that the algorithms would visit the target vertex (which was form the global vertices) for visualizing.

Also as a bonus made patrolling map generator twice as fast and reduce code duplication in patrolling algorithms.