### PR TITLE
Fault injection destroy robots

### DIFF
--- a/Assets/PlayModeTests/FaultInjections.meta
+++ b/Assets/PlayModeTests/FaultInjections.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 98c10e81aeaf463b9d0acef60ca6ca7b
+timeCreated: 1732019475

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f88a1abb5bd428295072c7ef4d26d4c
+timeCreated: 1732019492

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs
@@ -1,0 +1,93 @@
+using System.Collections;
+
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Robot;
+using Maes.Simulation;
+using Maes.Simulation.SimulationScenarios;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace PlayModeTests.FaultInjections.DestroyRobots
+{
+    using MySimulationScenario = ExplorationSimulationScenario;
+    using MySimulator = ExplorationSimulator;
+
+    /*
+     * This test checks that multiple scenarios can be run without fail when enabling fault injection.
+     * We are destroying robots from the simulation, it might have affect the rest of the scenarios since we are destorying before the scenario is finished.
+     */
+    [TestFixture(5, 3, 1)]
+    [TestFixture(2, 1, 2)]
+    [TestFixture(1, 0, 3)]
+    [TestFixture(1, 1, 5)]
+    [TestFixture(2, 2, 7)]
+    public class CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest
+    {
+        private const float Probability = 0.7f;
+        private const int RandomSeed = 123;
+        private const int InvokeEvery = 1;
+        private MySimulator _maes;
+        private readonly ExplorationSimulation _simulationBase;
+        private readonly int _robotsToSpawn;
+        private readonly int _robotsToDestroy;
+        private readonly int _scenarioToRun;
+
+        public CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest(int robotsToSpawn, int robotsToDestroy, int scenarioToRun)
+        {
+            _robotsToSpawn = robotsToSpawn;
+            _robotsToDestroy = robotsToDestroy;
+            _scenarioToRun = scenarioToRun;
+        }
+
+        [SetUp]
+        public void InitializeTestingSimulator()
+        {
+            _maes = new MySimulator();
+            for (var i = 0; i < _scenarioToRun; i++)
+            {
+                var testingScenario = new MySimulationScenario(RandomSeed,
+                    mapSpawner: StandardTestingConfiguration.EmptyCaveMapSpawner(RandomSeed),
+                    hasFinishedSim: sim => sim.SimulatedLogicTicks > _robotsToSpawn,
+                    robotConstraints: new RobotConstraints(),
+                    robotSpawner: (map, spawner) => spawner.SpawnRobotsTogether(map, RandomSeed, _robotsToSpawn,
+                        Vector2Int.zero, _ => new TestingAlgorithm()),
+                    faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToDestroy));
+                _maes.EnqueueScenario(testingScenario);
+            }
+        }
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _maes.Destroy();
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator DestroyRobotRandom_CheckRobotsDestroyFromStartToNumberOfRobotsToDestroy()
+        {
+            _maes.PressPlayButton();
+
+            // Wait until the robots are destroyed
+            while (ShouldContinue())
+            {
+                yield return null;
+            }
+
+            // Assert that the robots are destroyed
+            Assert.AreEqual(0, _maes.SimulationManager.Scenarios.Count);
+        }
+
+        private bool ShouldContinue()
+        {
+            if (_maes.SimulationManager.Scenarios.Count > 0)
+            {
+                return true;
+            }
+
+            var sim = _maes.SimulationManager.CurrentSimulation;
+            return sim != null && sim.SimulatedLogicTicks <= _robotsToSpawn;
+        }
+    }
+}

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 490a4dbec25844d2a1f5e3218ffa80c7
+timeCreated: 1732094014

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d3a9f6f11b8d49cc81e826c99982cb36
+timeCreated: 1732093957

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections;
+
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Robot;
+using Maes.Simulation;
+using Maes.Simulation.SimulationScenarios;
+using Maes.UI;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace PlayModeTests.FaultInjections.DestroyRobots.Random
+{
+    using MySimulationScenario = ExplorationSimulationScenario;
+    using MySimulator = ExplorationSimulator;
+
+    /*
+     * This test checks that a robot are destroyed every tick from the start to the number of robots to destroy
+     * This also check that no more robots are destroyed after the number of robots to destroy by running 10 more logic ticks
+     */
+    [TestFixture(1, 1)]
+    [TestFixture(1, 0)]
+    [TestFixture(2, 2)]
+    [TestFixture(5, 3)]
+    [TestFixture(10, 7)]
+    public class DestroyRobotsRandomEveryTickFaultInjectionTest
+    {
+        private const float Probability = 1f;
+        private const int RandomSeed = 123;
+        private const int InvokeEvery = 1;
+        private MySimulator _maes;
+        private ExplorationSimulation _simulationBase;
+        private readonly int _robotsToSpawn;
+        private readonly int _robotsToDestroy;
+
+        public DestroyRobotsRandomEveryTickFaultInjectionTest(int robotsToSpawn, int robotsToDestroy)
+        {
+            _robotsToSpawn = robotsToSpawn;
+            _robotsToDestroy = robotsToDestroy;
+        }
+
+        [SetUp]
+        public void InitializeTestingSimulator()
+        {
+            var testingScenario = new MySimulationScenario(RandomSeed,
+                mapSpawner: StandardTestingConfiguration.EmptyCaveMapSpawner(RandomSeed),
+                hasFinishedSim: _ => false,
+                robotConstraints: new RobotConstraints(),
+                robotSpawner: (map, spawner) => spawner.SpawnRobotsTogether(map, RandomSeed, _robotsToSpawn,
+                    Vector2Int.zero, _ => new TestingAlgorithm()),
+                faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToDestroy));
+
+            _maes = new MySimulator();
+            _maes.EnqueueScenario(testingScenario);
+            _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
+        }
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _maes.Destroy();
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator DestroyRobotRandom_CheckRobotsDestroyFromStartToNumberOfRobotsToDestroy()
+        {
+            var expectedNumberOfRobotsAfterDestroyed = _robotsToSpawn - _robotsToDestroy;
+
+            _maes.PressPlayButton();
+
+            // Wait until the robots are destroyed
+            while (_simulationBase.SimulatedLogicTicks <= _robotsToDestroy)
+            {
+                yield return null;
+            }
+
+            // Assert that the robots are destroyed
+            Assert.AreEqual(expectedNumberOfRobotsAfterDestroyed, _simulationBase.RobotSpawner.transform.childCount);
+
+            _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+            // Run 10 more ticks to ensure that no more robots are destroyed
+            while (_simulationBase.SimulatedLogicTicks <= _robotsToDestroy + 10)
+            {
+                yield return null;
+            }
+
+            // Assert that the robots are destroyed
+            Assert.AreEqual(expectedNumberOfRobotsAfterDestroyed, _simulationBase.RobotSpawner.transform.childCount);
+        }
+    }
+}

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aa60f12cf99c4131a7808302daf71308
+timeCreated: 1732019527

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections;
+
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Robot;
+using Maes.Simulation;
+using Maes.Simulation.SimulationScenarios;
+using Maes.UI;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace PlayModeTests.FaultInjections.DestroyRobots.Random
+{
+    using MySimulationScenario = ExplorationSimulationScenario;
+    using MySimulator = ExplorationSimulator;
+
+    /*
+     * This test class checks no robots are destroyed when the probability of destroying a robot is 0,
+     * even though the number of robots to destroy is the number of robots to spawn
+     */
+    [TestFixture(1)]
+    [TestFixture(2)]
+    [TestFixture(5)]
+    [TestFixture(10)]
+    public class DestroyRobotsRandomZeroProbabilityFaultInjectionTest
+    {
+        private const float Probability = 0;
+        private const int RandomSeed = 123;
+        private const int InvokeEvery = 1;
+        private MySimulator _maes;
+        private ExplorationSimulation _simulationBase;
+        private readonly int _robotsToSpawn;
+
+        public DestroyRobotsRandomZeroProbabilityFaultInjectionTest(int robotsToSpawn)
+        {
+            _robotsToSpawn = robotsToSpawn;
+        }
+
+        [SetUp]
+        public void InitializeTestingSimulator()
+        {
+            var testingScenario = new MySimulationScenario(RandomSeed,
+                mapSpawner: StandardTestingConfiguration.EmptyCaveMapSpawner(RandomSeed),
+                hasFinishedSim: _ => false,
+                robotConstraints: new RobotConstraints(),
+                robotSpawner: (map, spawner) => spawner.SpawnRobotsTogether(map, RandomSeed, _robotsToSpawn,
+                    Vector2Int.zero, _ => new TestingAlgorithm()),
+                faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToSpawn));
+
+            _maes = new MySimulator();
+            _maes.EnqueueScenario(testingScenario);
+            _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
+        }
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _maes.Destroy();
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator DestroyRobotRandom_ZeroDestroyedEnd()
+        {
+            var expectedRobotsAtEnd = _simulationBase.Robots.Count;
+
+            _maes.PressPlayButton();
+            _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+
+            while (_simulationBase.SimulatedLogicTicks < (_robotsToSpawn + 100))
+            {
+                yield return null;
+            }
+
+            // Assert that no robots are destroyed
+            Assert.AreEqual(expectedRobotsAtEnd, _simulationBase.RobotSpawner.transform.childCount);
+        }
+    }
+}

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 716b5863509e4483a9a413484d633307
+timeCreated: 1732093006

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4d481452bb374ee58127453d837d6cec
+timeCreated: 1732098121

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections;
+
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Robot;
+using Maes.Simulation;
+using Maes.Simulation.SimulationScenarios;
+using Maes.UI;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace PlayModeTests.FaultInjections.DestroyRobots.SpecificTick
+{
+    using MySimulationScenario = ExplorationSimulationScenario;
+    using MySimulator = ExplorationSimulator;
+
+    /*
+     * Test that robots are destroyed at specific ticks
+     */
+    [TestFixture]
+    public class DestroyRobotsAtTicksFaultInjectionTest
+    {
+        public class TestCase
+        {
+            public readonly string Name;
+            public readonly int RobotsToSpawn;
+            public readonly int[] RobotsToDestroyAtTicks;
+            public TestCase(string name, int robotsToSpawn, int[] robotsToDestroyAtTicks)
+            {
+                Name = name;
+                RobotsToSpawn = robotsToSpawn;
+                RobotsToDestroyAtTicks = robotsToDestroyAtTicks;
+            }
+        }
+
+        private class TestCasesDestroyAtTicks
+        {
+            private static readonly TestCase[] Cases =
+            {
+                new("10 robots no ticks", 10, Array.Empty<int>()),
+                new("1 robot - Destroy at tick 0", 1, new []{1}),
+                new("1 robots - Destroy at tick 1", 1, new []{1}),
+                new("2 robots - Destroy at ticks 5", 2, new []{5}),
+                new("12 robots - Destroy at ticks 5,10", 12, new []{5, 8}),
+                new("12 robots - Destroy at ticks 2,3,7,10", 12, new []{2, 3, 7, 8, 10}),
+            };
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    foreach (var testCase in Cases)
+                    {
+                        yield return new TestCaseData(testCase).Returns(null);
+                    }
+                }
+            }
+        }
+
+        private const int RandomSeed = 123;
+        private MySimulator _maes;
+        private ExplorationSimulation _simulationBase;
+
+        private void InitializeTestingSimulator(int robotsToSpawn, int[] robotsToDestroyAtTicks, string testCaseName)
+        {
+            var testingScenario = new MySimulationScenario(RandomSeed,
+                mapSpawner: StandardTestingConfiguration.EmptyCaveMapSpawner(RandomSeed),
+                hasFinishedSim: _ => false,
+                robotConstraints: new RobotConstraints(),
+                robotSpawner: (map, spawner) => spawner.SpawnRobotsTogether(map, RandomSeed, robotsToSpawn,
+                    Vector2Int.zero, _ => new TestingAlgorithm()),
+                faultInjection: new DestroyRobotsAtSpecificTickFaultInjection(RandomSeed, robotsToDestroyAtTicks));
+
+            _maes = new MySimulator();
+            _maes.EnqueueScenario(testingScenario);
+            _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
+
+            var tracker = new DestroyTrackerTest(_simulationBase, robotsToDestroyAtTicks, robotsToSpawn, testCaseName);
+
+            foreach (var robot in _simulationBase.Robots)
+            {
+                ((TestingAlgorithm)robot.Algorithm).UpdateFunction = (tick, _) =>
+                {
+                    tracker.UpdateLogic(tick, _simulationBase.RobotSpawner.transform.childCount);
+                };
+            }
+        }
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _maes?.Destroy();
+        }
+
+        private class DestroyTrackerTest
+        {
+            private ExplorationSimulation Simulation { get; }
+            private int[] RobotsToDestroyAtTicks { get; }
+            private int RobotsToSpawn { get; }
+            private string TestCaseName { get; }
+            private int Tick { get; set; } = -1;
+            private readonly int _index;
+
+            public DestroyTrackerTest(ExplorationSimulation simulation, int[] robotsToDestroyAtTicks, int robotsToSpawn, string testCaseName)
+            {
+                Simulation = simulation;
+                RobotsToDestroyAtTicks = robotsToDestroyAtTicks;
+                RobotsToSpawn = robotsToSpawn;
+                TestCaseName = testCaseName;
+            }
+
+            public void UpdateLogic(int tick, int robotCount)
+            {
+                if (Tick >= tick)
+                {
+                    return;
+                }
+
+                // Check that the robots are destroyed at the correct ticks
+                var destroyed = 0;
+                var recentTick = 0;
+                foreach (var destroyAtTick in RobotsToDestroyAtTicks)
+                {
+                    if (destroyAtTick <= tick)
+                    {
+                        destroyed++;
+                        recentTick = destroyAtTick;
+                    }
+                }
+
+                if (recentTick + 5 < tick) // +5 because allows some time for the robots to be destroyed
+                {
+                    Assert.AreEqual(RobotsToSpawn - destroyed, robotCount, $"Simulated Logic Tick: {tick}, Destroyed: {destroyed}, Count:{Simulation.RobotSpawner.transform.childCount}, Name: {TestCaseName}");
+                }
+
+                Tick = tick;
+            }
+        }
+
+        [Test(ExpectedResult = null)]
+        [TestCaseSource(typeof(TestCasesDestroyAtTicks), nameof(TestCasesDestroyAtTicks.TestCases))]
+        public IEnumerator DestroyRobotAtSpecificTicks(TestCase testCase)
+        {
+            var robotsToSpawn = testCase.RobotsToSpawn;
+            var robotsToDestroyAtTicks = testCase.RobotsToDestroyAtTicks;
+
+            InitializeTestingSimulator(robotsToSpawn, robotsToDestroyAtTicks, testCase.Name);
+
+            var expectedNumberOfRobotsAfterDestroyed = robotsToSpawn - robotsToDestroyAtTicks.Length;
+
+            _maes.PressPlayButton();
+            _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+
+            var stop = robotsToDestroyAtTicks.Length == 0 ? 0 : robotsToDestroyAtTicks[^1] + 2;
+
+            while (_simulationBase.SimulatedLogicTicks <= stop + 10)
+            {
+                yield return null;
+            }
+
+            // Assert that the robots are destroyed
+            Assert.AreEqual(expectedNumberOfRobotsAfterDestroyed, _simulationBase.RobotSpawner.transform.childCount, $"expectedNumberOfRobotsAfterDestroyed: {expectedNumberOfRobotsAfterDestroyed}, Count:{_simulationBase.RobotSpawner.transform.childCount}, Name: {testCase.Name}");
+        }
+    }
+}

--- a/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs.meta
+++ b/Assets/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2aa563bc362d41ef8321080f3416eddb
+timeCreated: 1732098306

--- a/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperimentWithFaultInjection.cs
+++ b/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperimentWithFaultInjection.cs
@@ -1,0 +1,142 @@
+// Copyright 2024 MAES
+// 
+// This file is part of MAES
+// 
+// MAES is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAES is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAES. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: 
+// Rasmus Borrisholt Schmidt, 
+// Andreas Sebastian Sørensen, 
+// Thor Beregaard, 
+// Malte Z. Andreasen, 
+// Philip I. Holler,
+// Magnus K. Jensen, 	
+// Casper Nyvang Sørensen,
+// Christian Ziegler Sejersen,
+// Henrik van Peet,
+// Jakob Meyer Olsen,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+// 
+// Original repository: https://github.com/Molitany/MAES
+
+using System.Collections.Generic;
+
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Map.MapGen;
+using Maes.PatrollingAlgorithms;
+using Maes.Robot;
+using Maes.Simulation;
+using Maes.Simulation.SimulationScenarios;
+
+using UnityEngine;
+
+namespace Maes.ExperimentSimulations
+{
+    using MySimulationScenario = PatrollingSimulationScenario;
+    using MySimulator = PatrollingSimulator;
+
+    internal class ConscientiousReactiveExperimentWithFaultInjection : MonoBehaviour
+    {
+        private void Start()
+        {
+            var constraintsDict = new Dictionary<string, RobotConstraints>();
+
+            //var constraintsGlobalCommunication = new RobotConstraints(
+            constraintsDict["Global"] = new RobotConstraints(
+                senseNearbyAgentsRange: 5f,
+                senseNearbyAgentsBlockedByWalls: true,
+                automaticallyUpdateSlam: true,
+                slamUpdateIntervalInTicks: 1,
+                slamSynchronizeIntervalInTicks: 10,
+                slamPositionInaccuracy: 0.2f,
+                mapKnown: true,
+                distributeSlam: false,
+                environmentTagReadRange: 100f,
+                slamRayTraceRange: 7f,
+                relativeMoveSpeed: 1f,
+                agentRelativeSize: 0.6f,
+                calculateSignalTransmissionProbability: (_, _) => true);
+
+            //var constraintsMaterials = new RobotConstraints(
+            constraintsDict["Material"] = new RobotConstraints(
+                senseNearbyAgentsRange: 5f,
+                senseNearbyAgentsBlockedByWalls: true,
+                automaticallyUpdateSlam: true,
+                slamUpdateIntervalInTicks: 1,
+                slamSynchronizeIntervalInTicks: 10,
+                slamPositionInaccuracy: 0.2f,
+                mapKnown: true,
+                distributeSlam: false,
+                environmentTagReadRange: 100.0f,
+                slamRayTraceRange: 7f,
+                relativeMoveSpeed: 1f,
+                agentRelativeSize: 0.6f,
+                materialCommunication: true
+            );
+
+            //var constraintsLOS = new RobotConstraints(
+            constraintsDict["LOS"] = new RobotConstraints(
+                senseNearbyAgentsRange: 5f,
+                senseNearbyAgentsBlockedByWalls: true,
+                automaticallyUpdateSlam: true,
+                slamUpdateIntervalInTicks: 1,
+                slamSynchronizeIntervalInTicks: 10,
+                slamPositionInaccuracy: 0.2f,
+                mapKnown: true,
+                distributeSlam: false,
+                environmentTagReadRange: 100.0f,
+                slamRayTraceRange: 7f,
+                relativeMoveSpeed: 1f,
+                agentRelativeSize: 0.6f,
+                calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
+
+            var simulator = new MySimulator();
+            var random = new System.Random(12345);
+            var mapSize = 100;
+
+            var constraintName = "Global";
+            var robotConstraints = constraintsDict[constraintName];
+            var mapConfig = new BuildingMapConfig(123, widthInTiles: mapSize, heightInTiles: mapSize);
+            var algoName = "conscientious_reactive";
+            const int robotCount = 5;
+            var spawningPosList = new List<Vector2Int>();
+            for (var amountOfSpawns = 0; amountOfSpawns < robotCount; amountOfSpawns++)
+            {
+                spawningPosList.Add(new Vector2Int(random.Next(0, mapSize), random.Next(0, mapSize)));
+            }
+
+            simulator.EnqueueScenario(
+                new MySimulationScenario(
+                    seed: 123,
+                    totalCycles: 4,
+                    stopAfterDiff: false,
+                    mapSpawner: generator => generator.GenerateMap(mapConfig),
+                    robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
+                        collisionMap: buildingConfig,
+                        seed: 123,
+                        numberOfRobots: robotCount,
+                        spawnPositions: spawningPosList,
+                        createAlgorithmDelegate: (_) => new ConscientiousReactiveAlgorithm()),
+                    statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
+                    robotConstraints: robotConstraints,
+                    faultInjection: new DestroyRobotsRandomFaultInjection(123, 0.05f, 1000, 4)
+                )
+            );
+
+
+            simulator.PressPlayButton(); // Instantly enter play mode
+        }
+    }
+}

--- a/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperimentWithFaultInjection.cs.meta
+++ b/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperimentWithFaultInjection.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f73abcac235342b9897e4043b8bc9fe1
+timeCreated: 1732527829

--- a/Assets/Scripts/FaultInjections.meta
+++ b/Assets/Scripts/FaultInjections.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8e5eba3ac03543cca184ac80742e5564
+timeCreated: 1732010571

--- a/Assets/Scripts/FaultInjections/DestroyRobots.meta
+++ b/Assets/Scripts/FaultInjections/DestroyRobots.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 43289901cbc74942816f657b521af469
+timeCreated: 1732017085

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotBaseFaultInjection.cs
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotBaseFaultInjection.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+using Maes.Robot;
+
+namespace Maes.FaultInjections.DestroyRobots
+{
+    /// <summary>
+    /// Base class for destroying robots.
+    /// </summary>
+    public abstract class DestroyRobotBaseFaultInjection : IFaultInjection
+    {
+        protected readonly Random _random;
+        protected int DestroyedCount { get; private set; }
+
+        protected DestroyRobotBaseFaultInjection(int seed)
+        {
+            _random = new Random(seed);
+        }
+
+        public void LogicUpdate(List<MonaRobot> robots, int logicTick)
+        {
+            if (robots.Count > 0 && ShouldDestroy(logicTick))
+            {
+                DestroyOneRobot(robots);
+            }
+        }
+
+        /// <summary>
+        /// Whether a robot should be destroyed at <paramref name="logicTick"/>.
+        /// </summary>
+        protected abstract bool ShouldDestroy(int logicTick);
+
+        /// <summary>
+        /// Destroy a robot randomly for the list.
+        /// </summary>
+        private void DestroyOneRobot(List<MonaRobot> robots)
+        {
+            var robot = robots[_random.Next(0, robots.Count)];
+            if (robots.Remove(robot))
+            {
+                robot.DestroyRobot();
+                DestroyedCount++;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotBaseFaultInjection.cs.meta
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotBaseFaultInjection.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99035f72f9f24ef08d56f0e006f982c6
+timeCreated: 1732016905

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsAtSpecificTickFaultInjection.cs
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsAtSpecificTickFaultInjection.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Maes.FaultInjections.DestroyRobots
+{
+    /// <summary>
+    /// Destroy robots at specific ticks.
+    /// </summary>
+    public class DestroyRobotsAtSpecificTickFaultInjection : DestroyRobotBaseFaultInjection
+    {
+        private readonly int[] _destroyAtTicks;
+        private readonly int _currentNumberOfDestroys;
+        private int _index;
+
+        /// <summary>
+        /// Constructor for DestroyRobotsAtSpecificTickFaultInjection.
+        /// </summary>
+        /// <param name="seed">Seed for the random number generator.</param>
+        /// <param name="destroyAtTicks">Array of ticks at whihch robots should be destroyed.</param>
+        public DestroyRobotsAtSpecificTickFaultInjection(int seed, int[] destroyAtTicks) : base(seed)
+        {
+            _destroyAtTicks = destroyAtTicks;
+            Array.Sort(_destroyAtTicks);
+            _currentNumberOfDestroys = destroyAtTicks.Length;
+        }
+
+        protected override bool ShouldDestroy(int logicTick)
+        {
+            if (_index < _currentNumberOfDestroys && logicTick == _destroyAtTicks[_index])
+            {
+                _index++;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsAtSpecificTickFaultInjection.cs.meta
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsAtSpecificTickFaultInjection.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b8d8409db0764e1a86dc623d15251c2d
+timeCreated: 1732017058

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsRandomFaultInjection.cs
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsRandomFaultInjection.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Maes.FaultInjections.DestroyRobots
+{
+    /// <summary>
+    /// This fault injection destroys robots randomly with a given probability.
+    /// </summary>
+    public class DestroyRobotsRandomFaultInjection : DestroyRobotBaseFaultInjection
+    {
+        private readonly int? _maxDestroy;
+        private readonly float _probability;
+        private readonly int _invokeEvery;
+
+        /// <summary>
+        /// Constructor for DestroyRobotsRandomFaultInjection.
+        /// </summary>
+        /// <param name="seed">Seed for the random number generator.</param>
+        /// <param name="probability">Probability of destroying a robot.</param>
+        /// <param name="invokeEvery">How often the fault injection should be called.</param>
+        /// <param name="maxDestroy">Maximum number of robots to destroy.</param>
+        public DestroyRobotsRandomFaultInjection(int seed, float probability, int invokeEvery = 1, int? maxDestroy = null) : base(seed)
+        {
+            if (invokeEvery <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(invokeEvery), "Must be greater than 0");
+            }
+
+            if (_probability < 0.0 || _probability > 1.0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(probability), "Probability must be between 0.0 and 1.0");
+            }
+
+            _maxDestroy = maxDestroy;
+            _probability = probability;
+            _invokeEvery = invokeEvery;
+        }
+
+        protected override bool ShouldDestroy(int logicTick)
+        {
+            return _maxDestroy > DestroyedCount && logicTick % _invokeEvery == 0 && _random.NextDouble() < _probability;
+        }
+    }
+}

--- a/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsRandomFaultInjection.cs.meta
+++ b/Assets/Scripts/FaultInjections/DestroyRobots/DestroyRobotsRandomFaultInjection.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fd6ffb2025864619bc5083ee2105055e
+timeCreated: 1732010738

--- a/Assets/Scripts/FaultInjections/IFaultInjection.cs
+++ b/Assets/Scripts/FaultInjections/IFaultInjection.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+using Maes.Robot;
+
+namespace Maes.FaultInjections
+{
+    public interface IFaultInjection
+    {
+        void LogicUpdate(List<MonaRobot> robots, int logicTicks);
+    }
+}

--- a/Assets/Scripts/FaultInjections/IFaultInjection.cs.meta
+++ b/Assets/Scripts/FaultInjections/IFaultInjection.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7c53378456743ae978777aa2cba0039
+timeCreated: 1732015386

--- a/Assets/Scripts/Robot/CommunicationManager.cs
+++ b/Assets/Scripts/Robot/CommunicationManager.cs
@@ -69,7 +69,7 @@ namespace Maes.Robot
         private readonly List<Message> _readableMessages = new();
 
         private readonly RayTracingMap<Tile> _rayTracingMap;
-        private MonaRobot[] _robots = Array.Empty<MonaRobot>();
+        private List<MonaRobot> _robots = new();
 
         // Map for storing and retrieving all tags deposited by robots
         private readonly EnvironmentTaggingMap _environmentTaggingMap;
@@ -403,7 +403,7 @@ namespace Maes.Robot
             return sensedObjects;
         }
 
-        public void SetRobotReferences(MonaRobot[] robots)
+        public void SetRobotReferences(List<MonaRobot> robots)
         {
             _robots = robots;
         }

--- a/Assets/Scripts/Robot/MonaRobot.cs
+++ b/Assets/Scripts/Robot/MonaRobot.cs
@@ -129,5 +129,10 @@ namespace Maes.Robot
                 Gizmos.DrawWireSphere(point, radius);
             }
         }
+
+        public void DestroyRobot()
+        {
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/Scripts/Simulation/ISimulation.cs
+++ b/Assets/Scripts/Simulation/ISimulation.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Maes.Algorithms;
 using Maes.Map;
 using Maes.Robot;
@@ -24,7 +26,7 @@ namespace Maes.Simulation
 
         ITracker Tracker { get; }
 
-        MonaRobot[] Robots { get; }
+        List<MonaRobot> Robots { get; }
 
         void SetSelectedRobot(MonaRobot? newSelectedRobot);
 

--- a/Assets/Scripts/Simulation/SimulationScenarios/ExplorationSimulationScenario.cs
+++ b/Assets/Scripts/Simulation/SimulationScenarios/ExplorationSimulationScenario.cs
@@ -1,5 +1,6 @@
 using Maes.Algorithms;
 using Maes.ExplorationAlgorithm.RandomBallisticWalk;
+using Maes.FaultInjections;
 using Maes.Robot;
 
 using UnityEngine;
@@ -15,13 +16,15 @@ namespace Maes.Simulation.SimulationScenarios
             MapFactory? mapSpawner = null,
             RobotFactory<IExplorationAlgorithm>? robotSpawner = null,
             RobotConstraints? robotConstraints = null,
-            string? statisticsFileName = null)
+            string? statisticsFileName = null,
+            IFaultInjection? faultInjection = null)
             : base(seed,
                 robotSpawner ?? ((map, spawner) => spawner.SpawnRobotsTogether(map, seed, 1, Vector2Int.zero, robotSeed => new RandomExplorationAlgorithm(robotSeed))),
                 hasFinishedSim,
                 mapSpawner,
                 robotConstraints,
-                statisticsFileName)
+                statisticsFileName,
+                faultInjection)
         {
         }
     }

--- a/Assets/Scripts/Simulation/SimulationScenarios/PatrollingSimulationScenario.cs
+++ b/Assets/Scripts/Simulation/SimulationScenarios/PatrollingSimulationScenario.cs
@@ -1,4 +1,5 @@
 using Maes.Algorithms;
+using Maes.FaultInjections;
 using Maes.Map;
 using Maes.Map.MapGen;
 using Maes.Map.MapPatrollingGen;
@@ -25,14 +26,15 @@ namespace Maes.Simulation.SimulationScenarios
             RobotFactory<IPatrollingAlgorithm>? robotSpawner = null,
             RobotConstraints? robotConstraints = null,
             string? statisticsFileName = null,
-            PatrollingMapFactory? patrollingMapFactory = null
-            )
+            PatrollingMapFactory? patrollingMapFactory = null,
+            IFaultInjection? faultInjection = null)
             : base(seed,
                 robotSpawner ?? ((map, spawner) => spawner.SpawnRobotsTogether(map, seed, 1, Vector2Int.zero, _ => new ConscientiousReactiveAlgorithm())),
                 null,
                 mapSpawner,
                 robotConstraints,
-                statisticsFileName)
+                statisticsFileName,
+                faultInjection)
         {
             TotalCycles = totalCycles;
             StopAfterDiff = stopAfterDiff;

--- a/Assets/Scripts/Simulation/SimulationScenarios/SimulationScenario.cs
+++ b/Assets/Scripts/Simulation/SimulationScenarios/SimulationScenario.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 
 using Maes.Algorithms;
+using Maes.FaultInjections;
 using Maes.Map;
 using Maes.Map.MapGen;
 using Maes.Map.RobotSpawners;
@@ -53,13 +54,16 @@ namespace Maes.Simulation.SimulationScenarios
         public RobotConstraints RobotConstraints { get; }
         public string StatisticsFileName { get; }
 
+        public IFaultInjection? FaultInjection { get; }
+
         protected SimulationScenario(
             int seed,
             RobotFactory<TAlgorithm> robotSpawner,
             SimulationEndCriteriaDelegate<TSimulation>? hasFinishedSim = null,
             MapFactory? mapSpawner = null,
             RobotConstraints? robotConstraints = null,
-            string? statisticsFileName = null
+            string? statisticsFileName = null,
+            IFaultInjection? faultInjection = null
             )
         {
             HasFinishedSim = hasFinishedSim ?? (simulation => simulation.HasFinishedSim());
@@ -68,6 +72,7 @@ namespace Maes.Simulation.SimulationScenarios
             RobotSpawner = robotSpawner;
             RobotConstraints = robotConstraints ?? new RobotConstraints();
             StatisticsFileName = statisticsFileName ?? $"statistics_{DateTime.Now.ToShortDateString().Replace('/', '-')}_{DateTime.Now.ToLongTimeString().Replace(' ', '-').Replace(':', '-')}";
+            FaultInjection = faultInjection;
         }
     }
 }

--- a/Assets/Scripts/Statistics/CommunicationTracker.cs
+++ b/Assets/Scripts/Statistics/CommunicationTracker.cs
@@ -51,6 +51,11 @@ namespace Maes.Statistics
                 return;
             }
 
+            if (CommunicationGroups.Count == 0)
+            {
+                return;
+            }
+
             // if we have exactly one group, then every agent must be in it!
             if (CommunicationGroups.Count == 1)
             {

--- a/Assets/Scripts/Statistics/ExplorationTracker.cs
+++ b/Assets/Scripts/Statistics/ExplorationTracker.cs
@@ -75,15 +75,15 @@ namespace Maes.Statistics
             SnapShots.Add(new ExplorationSnapShot(_currentTick, ExploredProportion, CoverageProportion, _mostRecentDistance));
         }
 
-        private static float CalculateAverageDistance(MonaRobot[] robots)
+        private static float CalculateAverageDistance(List<MonaRobot> robots)
         {
             var sum = 0f;
             var count = 0;
-            for (var i = 0; i < robots.Length; i++)
+            for (var i = 0; i < robots.Count; i++)
             {
                 var robot = robots[i];
                 var robotPosition = robot.transform.position;
-                for (var j = i + 1; j < robots.Length; j++)
+                for (var j = i + 1; j < robots.Count; j++)
                 {
                     var otherRobot = robots[j];
                     var otherRobotPosition = otherRobot.transform.position;
@@ -129,7 +129,7 @@ namespace Maes.Statistics
             return new Vector2Int((int)robotPosition.x, (int)robotPosition.y);
         }
 
-        protected override void OnAfterFirstTick(MonaRobot[] robots)
+        protected override void OnAfterFirstTick(List<MonaRobot> robots)
         {
             _mostRecentDistance = CalculateAverageDistance(robots);
             base.OnAfterFirstTick(robots);
@@ -190,7 +190,7 @@ namespace Maes.Statistics
             SetVisualizationMode(new SelectedRobotSlamMapVisualization(_selectedRobot.Controller));
         }
 
-        protected override void OnBeforeLogicUpdate(MonaRobot[] robots)
+        protected override void OnBeforeLogicUpdate(List<MonaRobot> robots)
         {
             base.OnBeforeLogicUpdate(robots);
 
@@ -202,7 +202,7 @@ namespace Maes.Statistics
         }
 
         // Updates both exploration tracker and robot slam maps
-        private void PerformRayTracing(MonaRobot[] robots, bool shouldUpdateSlamMap)
+        private void PerformRayTracing(List<MonaRobot> robots, bool shouldUpdateSlamMap)
         {
             var visibilityRange = _constraints.SlamRayTraceRange;
 

--- a/Assets/Scripts/Trackers/ITracker.cs
+++ b/Assets/Scripts/Trackers/ITracker.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Maes.Robot;
 
 namespace Maes.Trackers
@@ -6,7 +8,7 @@ namespace Maes.Trackers
     {
         void UIUpdate();
 
-        void LogicUpdate(MonaRobot[] robots);
+        void LogicUpdate(List<MonaRobot> robots);
 
         void SetVisualizedRobot(MonaRobot? robot);
     }

--- a/Assets/Scripts/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Trackers/PatrollingTracker.cs
@@ -125,7 +125,7 @@ namespace Maes.Trackers
             }
         }
 
-        protected override void OnLogicUpdate(MonaRobot[] robots)
+        protected override void OnLogicUpdate(List<MonaRobot> robots)
         {
             var worstGraphIdleness = 0;
             var graphIdlenessSum = 0;

--- a/Assets/Scripts/Trackers/Tracker.cs
+++ b/Assets/Scripts/Trackers/Tracker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Maes.Map;
 using Maes.Map.MapGen;
@@ -56,7 +57,7 @@ namespace Maes.Trackers
             _currentVisualizationMode.UpdateVisualization(_visualizer, _currentTick);
         }
 
-        public void LogicUpdate(MonaRobot[] robots)
+        public void LogicUpdate(List<MonaRobot> robots)
         {
             OnBeforeLogicUpdate(robots);
 
@@ -93,12 +94,12 @@ namespace Maes.Trackers
             _currentTick++;
         }
 
-        protected virtual void OnBeforeLogicUpdate(MonaRobot[] robots) { }
-        protected virtual void OnLogicUpdate(MonaRobot[] robots) { }
+        protected virtual void OnBeforeLogicUpdate(List<MonaRobot> robots) { }
+        protected virtual void OnLogicUpdate(List<MonaRobot> robots) { }
 
         public abstract void SetVisualizedRobot(MonaRobot? robot);
 
-        protected virtual void OnAfterFirstTick(MonaRobot[] robots)
+        protected virtual void OnAfterFirstTick(List<MonaRobot> robots)
         {
             foreach (var robot in robots)
             {


### PR DESCRIPTION
A fault injection can be attached to the scenario.

Fault injection
- Able to destroy robots at random tick with a probability for destroy at tick and also whether it should run every tick or at every x'th tick.
- Able to destroy robots at the specified ticks

I also have made test case using exploration.
- One of the test case includes testing multiple scenario, to ensure that the simulator still can proceed to the next scenario even some robots are destroyed.