### PR TITLE
Patrolling: Use pathsteps to move instead of tiles

### DIFF
--- a/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperiment.cs
+++ b/Assets/Scripts/ExperimentSimulations/ConscientiousReactiveExperiment.cs
@@ -109,7 +109,6 @@ namespace Maes.ExperimentSimulations
             var robotConstraints = constraintsDict[constraintName];
             var mapConfig = new BuildingMapConfig(123, widthInTiles: mapSize, heightInTiles: mapSize);
             var algoName = "conscientious_reactive";
-            var algorithm = new ConscientiousReactiveAlgorithm();
             const int robotCount = 1;
             var spawningPosList = new List<Vector2Int>();
             for (var amountOfSpawns = 0; amountOfSpawns < robotCount; amountOfSpawns++)

--- a/Assets/Scripts/Map/CoarseGrainedMap.cs
+++ b/Assets/Scripts/Map/CoarseGrainedMap.cs
@@ -404,7 +404,7 @@ namespace Maes.Map
             var path = GetPath(target, beOptimistic: false);
             return path == null
                 ? null
-                : _aStar.PathToSteps(path, 0f);
+                : _aStar.PathToSteps(path);
         }
 
         /// <returns>whether or not a tile at a given position is solid.</returns>

--- a/Assets/Scripts/Map/PathFinding/AStar.cs
+++ b/Assets/Scripts/Map/PathFinding/AStar.cs
@@ -229,7 +229,7 @@ namespace Maes.Map.PathFinding
         }
 
         // Converts the given A* path to PathSteps (containing a line and a list of all tiles intersected in this path)
-        public List<PathStep> PathToSteps(Vector2Int[] path, float robotRadius = 0.4f)
+        public List<PathStep> PathToSteps(Vector2Int[] path)
         {
             if (path.Length == 1)
             {
@@ -260,6 +260,36 @@ namespace Maes.Map.PathFinding
             }
 
             steps.Add(new PathStep(stepStart, currentTile, crossedTiles));
+            return steps;
+        }
+
+        public static List<PathStep> PathToStepsCheap(Vector2Int[] path)
+        {
+            if (path.Length == 1)
+            {
+                return new List<PathStep> { new(path[0], path[0], null!) }; // HACK: set to null to avoid allocations.
+            }
+
+            var steps = new List<PathStep>();
+
+            var stepStart = path[0];
+            var currentTile = path[1];
+            var currentDirection = CardinalDirection.FromVector(currentTile - stepStart);
+
+            foreach (var nextTile in path.AsSpan(2))
+            {
+                var newDirection = CardinalDirection.FromVector(nextTile - currentTile);
+                if (newDirection != currentDirection)
+                {
+                    // New path step reached
+                    steps.Add(new PathStep(stepStart, currentTile, null!)); // HACK: set to null to avoid allocations.
+                    stepStart = currentTile;
+                    currentDirection = newDirection;
+                }
+                currentTile = nextTile;
+            }
+
+            steps.Add(new PathStep(stepStart, currentTile, null!)); // HACK: set to null to avoid allocations.
             return steps;
         }
 

--- a/Assets/Scripts/Map/PathFinding/IPathFinder.cs
+++ b/Assets/Scripts/Map/PathFinding/IPathFinder.cs
@@ -34,7 +34,7 @@ namespace Maes.Map.PathFinding
 
         public Vector2Int[]? GetOptimisticPath(Vector2Int startCoordinate, Vector2Int targetCoordinate, IPathFindingMap pathFindingMap, bool acceptPartialPaths = false);
 
-        public List<PathStep> PathToSteps(Vector2Int[] path, float robotRadius);
+        public List<PathStep> PathToSteps(Vector2Int[] path);
 
         public Vector2Int? GetNearestTileFloodFill(IPathFindingMap pathFindingMap, Vector2Int targetCoordinate, SlamTileStatus lookupStatus, HashSet<Vector2Int>? excludedTiles = null);
 

--- a/Assets/Scripts/Map/VisibleTilesCoarseMap.cs
+++ b/Assets/Scripts/Map/VisibleTilesCoarseMap.cs
@@ -88,7 +88,7 @@ namespace Maes.Map
         public List<PathStep>? GetPathSteps(Vector2Int coarseTileFrom, Vector2Int coarseTileTo, bool acceptPartialPaths = false)
         {
             var path = _aStar.GetOptimisticPath(coarseTileFrom, coarseTileTo, this, acceptPartialPaths);
-            return path == null ? null : _aStar.PathToSteps(path, 0.4f);
+            return path == null ? null : _aStar.PathToSteps(path);
         }
 
         public bool IsOptimisticSolid(Vector2Int coordinate)

--- a/Assets/Scripts/Statistics/PatrollingVisualizer.cs
+++ b/Assets/Scripts/Statistics/PatrollingVisualizer.cs
@@ -50,8 +50,14 @@ namespace Maes.Statistics
                 {
                     var edgeVisualizer = Instantiate(EdgeVisualizer, transform);
                     var lineRenderer = edgeVisualizer.GetComponent<LineRenderer>();
-                    lineRenderer.SetPosition(0, ((Vector3)(Vector2)vertex.Position) + transform.position + Vector3.back);
-                    lineRenderer.SetPosition(1, ((Vector3)(Vector2)otherVertex.Position) + transform.position + Vector3.back);
+
+                    var paths = _patrollingMap.Paths[(vertex.Id, otherVertex.Id)];
+                    lineRenderer.positionCount = paths.Length + 1;
+                    lineRenderer.SetPosition(0, ((Vector3)(Vector2)paths[0].Start) + transform.position + Vector3.back);
+                    for (var i = 0; i < paths.Length; i++)
+                    {
+                        lineRenderer.SetPosition(i + 1, ((Vector3)(Vector2)paths[i].End) + transform.position + Vector3.back);
+                    }
                     lineRenderer.material.color = vertex.Color;
 
                     _visualizers.Add(edgeVisualizer);


### PR DESCRIPTION
Before it would stop at every tile.
Now if there is a straight line it moves uninterrupted to the end of the line.

Patrolling visualizer now shows the pathsteps for the neighbors.
![1732269772](https://github.com/user-attachments/assets/29552b8b-8eea-4f7f-aa09-c9ec4d34c805)
