### PR TITLE
Fix: use different path when colliding

### DIFF
--- a/Assets/Scripts/PatrollingAlgorithms/PatrollingAlgorithm.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/PatrollingAlgorithm.cs
@@ -80,7 +80,15 @@ namespace Maes.PatrollingAlgorithms
 
             if (_currentPath.Count != 0)
             {
-                PathAndMoveToTarget();
+                if (_controller.IsCurrentlyColliding)
+                {
+                    _controller.PathAndMoveTo(TargetVertex.Position);
+
+                }
+                else
+                {
+                    PathAndMoveToTarget();
+                }
                 return;
             }
 


### PR DESCRIPTION
This fixes a weird bug where the robot would get stuck in a wall after some cycles.
Only on linux...