### PR TITLE
Remove bool _hasWrittenStatistics from simulationBase

### DIFF
--- a/Assets/Scripts/Simulation/SimulationBase.cs
+++ b/Assets/Scripts/Simulation/SimulationBase.cs
@@ -232,13 +232,11 @@ namespace Maes.Simulation
             }
         }
 
-        private bool _hasWrittenStatistics;
         public virtual void OnSimulationFinished()
         {
-            if (GlobalSettings.ShouldWriteCsvResults && !_hasWrittenStatistics)
+            if (GlobalSettings.ShouldWriteCsvResults)
             {
                 CreateStatisticsFile();
-                _hasWrittenStatistics = true;
             }
         }
 


### PR DESCRIPTION
OnSimulationFinished is only called once, and therefore the bool can be removed