### PR TITLE
Add a test for ComputeVisibilityOfPoint

### DIFF
--- a/Assets/EditTests/ComputeVisibilityTest.cs
+++ b/Assets/EditTests/ComputeVisibilityTest.cs
@@ -12,8 +12,7 @@ namespace EditTests
     /// the SaveAsImage.SaveVisibileTiles() debug method in the following method in WatchmanRouteSolver.cs: 
     /// private static Dictionary<Vector2Int, HashSet<Vector2Int>> ComputeVisibility(bool[,] map)
     /// In short, the ComputeVisibilityOfPointFastBreakColumn, will break the loop when it finds a column without any visible tiles.
-    /// However, visibility is calculated based on the centers of the tiles, 
-    /// so it is possible that there is a column with visible tiles after a column with no visible tiles.
+    /// However, due to the way visibility is calculated, it is possible that there is a column with visible tiles after a column with no visible tiles.
     /// </summary>
     public class ComputeVisibilityTest
     {

--- a/Assets/EditTests/ComputeVisibilityTest.cs
+++ b/Assets/EditTests/ComputeVisibilityTest.cs
@@ -6,18 +6,29 @@ using UnityEngine;
 
 namespace EditTests
 {
+    /// <summary>
+    /// These tests are for the ComputeVisibilityOfPoint and ComputeVisibilityOfPointFastBreakColumn methods.
+    /// To get a better understanding of the the difference between the two algorithms please use
+    /// the SaveAsImage.SaveVisibileTiles() debug method in the following method in WatchmanRouteSolver.cs: 
+    /// private static Dictionary<Vector2Int, HashSet<Vector2Int>> ComputeVisibility(bool[,] map)
+    /// In short, the ComputeVisibilityOfPointFastBreakColumn, will break the loop when it finds a column without any visible tiles.
+    /// However, visibility is calculated based on the centers of the tiles, 
+    /// so it is possible that there is a column with visible tiles after a column with no visible tiles.
+    /// </summary>
     public class ComputeVisibilityTest
     {
         public class TestCase
         {
             public string Name;
             public bool[,] Map;
-            public int Expected;
-            public TestCase(string name, bool[,] map, int expected)
+            public int ExpectedByOriginal;
+            public int ExpectedByOptimized;
+            public TestCase(string name, bool[,] map, int expectedByOriginal, int expectedByOptimized = -1)
             {
                 Name = name;
                 Map = map;
-                Expected = expected;
+                ExpectedByOriginal = expectedByOriginal;
+                ExpectedByOptimized = expectedByOptimized == -1 ? expectedByOriginal : expectedByOptimized;
             }
         }
 
@@ -81,6 +92,17 @@ namespace EditTests
                 {false, true},
                 {false, false},
             }, 4),
+            new TestCase("3x9 difference between original and optimized", new bool[,] {
+                {false, false, true},
+                {false, false, true},
+                {false, false, true},
+                {false, false, true},
+                {false, false, true},
+                {false, false, true},
+                {false, false, true},
+                {true, true, false},
+                {true, true, false},
+            }, 2*7+1, 2*7),
             };
 
         [Theory]
@@ -88,7 +110,7 @@ namespace EditTests
         public void ComputeVisibilityOfPointTests(TestCase testCase)
         {
             var map = testCase.Map;
-            var expected = testCase.Expected;
+            var expected = testCase.ExpectedByOriginal;
             var result = LineOfSightUtilities.ComputeVisibilityOfPoint(new Vector2Int(0, 0), map);
             Assert.AreEqual(expected, result.Count, $"Name: {testCase.Name}");
         }
@@ -98,7 +120,7 @@ namespace EditTests
         public void ComputeVisibilityOfPointFastBreakColumnTests(TestCase testCase)
         {
             var map = testCase.Map;
-            var expected = testCase.Expected;
+            var expected = testCase.ExpectedByOptimized;
             var result = LineOfSightUtilities.ComputeVisibilityOfPointFastBreakColumn(new Vector2Int(0, 0), map);
             Assert.AreEqual(expected, result.Count, $"Name: {testCase.Name}");
         }


### PR DESCRIPTION
This test case illustrates the difference between the original and optimized version.
The test case added:
![image](https://github.com/user-attachments/assets/af50a327-c996-461d-8fb3-26b82c859d13)
Blue is starting point, red is not visible by any of them. Therefore making the 8th column not contain any visible tiles, causing the optimized version to stop prematurely. Green is therefore only visible by the original algorithm but not the optimized version. Currently, the original version is in use in the program. 