### PR TITLE
target waypoint visualizer: Use IPatrollingAlgorithm instead

### DIFF
--- a/Assets/Scripts/Algorithms/IAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/IAlgorithm.cs
@@ -4,11 +4,11 @@ namespace Maes.Algorithms
 {
     public interface IAlgorithm
     {
-        public void UpdateLogic();
+        void UpdateLogic();
 
-        public void SetController(Robot2DController controller);
+        void SetController(Robot2DController controller);
 
         // Returns debug info that will be shown when the robot is selected
-        public string GetDebugInfo();
+        string GetDebugInfo();
     }
 }

--- a/Assets/Scripts/Map/Visualization/Patrolling/PatrollingTargetWaypointVisualizationMode.cs
+++ b/Assets/Scripts/Map/Visualization/Patrolling/PatrollingTargetWaypointVisualizationMode.cs
@@ -1,4 +1,4 @@
-using Maes.PatrollingAlgorithms;
+using Maes.Algorithms;
 using Maes.Robot;
 using Maes.Statistics;
 
@@ -6,11 +6,11 @@ namespace Maes.Map.Visualization.Patrolling
 {
     internal class PatrollingTargetWaypointVisualizationMode : IPatrollingVisualizationMode
     {
-        private readonly PatrollingAlgorithm _algorithm;
+        private readonly IPatrollingAlgorithm _algorithm;
 
         public PatrollingTargetWaypointVisualizationMode(MonaRobot robot)
         {
-            _algorithm = (PatrollingAlgorithm)robot.Algorithm;
+            _algorithm = (IPatrollingAlgorithm)robot.Algorithm;
         }
 
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)


### PR DESCRIPTION
This allows for advanced algorithms that does not make use of the PatrollingAlgorithm base class.