### PR TITLE
Fix Cognitive Coordinated

### DIFF
--- a/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
@@ -12,6 +12,12 @@ namespace Maes.Algorithms
 
         void SetPatrollingMap(PatrollingMap map);
 
+        /// <summary>
+        /// A shared map. Should not be used in distributed algorithms.
+        /// </summary>
+        /// <param name="globalMap">The shared patrolling map.</param>
+        void SetGlobalPatrollingMap(PatrollingMap globalMap);
+
         void SubscribeOnReachVertex(OnReachVertex onReachVertex);
     }
 }

--- a/Assets/Scripts/ExperimentSimulations/CognitiveCoordinatedExperiment.cs
+++ b/Assets/Scripts/ExperimentSimulations/CognitiveCoordinatedExperiment.cs
@@ -84,7 +84,7 @@ namespace Maes.ExperimentSimulations
                         seed: 123,
                         numberOfRobots: robotCount,
                         spawnPositions: spawningPosList,
-                        createAlgorithmDelegate: (_) => new CognitiveCoordinated()),
+                        createAlgorithmDelegate: _ => new CognitiveCoordinated()),
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                     robotConstraints: robotConstraints
                 )

--- a/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
+++ b/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
@@ -25,6 +25,8 @@ namespace Maes.Map.RobotSpawners
             algorithm.SetPatrollingMap(_patrollingMap.Clone());
             algorithm.SubscribeOnReachVertex(_tracker.OnReachedVertex);
 
+            algorithm.SetGlobalPatrollingMap(_patrollingMap);
+
             return robot;
         }
     }

--- a/Assets/Scripts/Map/Vertex.cs
+++ b/Assets/Scripts/Map/Vertex.cs
@@ -52,5 +52,10 @@ namespace Maes.Map
         {
             _neighbors.Remove(neighbor);
         }
+
+        public override string ToString()
+        {
+            return $"Vertex {Id} @{Position}";
+        }
     }
 }

--- a/Assets/Scripts/PatrollingAlgorithms/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/ConscientiousReactiveAlgorithm.cs
@@ -8,9 +8,9 @@ namespace Maes.PatrollingAlgorithms
     {
         public override string AlgorithmName => "Conscientious Reactive Algorithm";
 
-        protected override Vertex NextVertex()
+        protected override Vertex NextVertex(Vertex currentVertex)
         {
-            return TargetVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
+            return currentVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
         }
     }
 }

--- a/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
@@ -13,7 +13,8 @@ namespace Maes.PatrollingAlgorithms
 
         protected override Vertex NextVertex()
         {
-            return TargetVertex.Neighbors.ElementAt(UnityEngine.Random.Range(0, TargetVertex.Neighbors.Count));
+            var index = UnityEngine.Random.Range(0, TargetVertex.Neighbors.Count);
+            return TargetVertex.Neighbors.ElementAt(index);
         }
     }
 }

--- a/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
+++ b/Assets/Scripts/PatrollingAlgorithms/RandomReactive.cs
@@ -11,10 +11,10 @@ namespace Maes.PatrollingAlgorithms
     {
         public override string AlgorithmName => "Random Reactive Algorithm";
 
-        protected override Vertex NextVertex()
+        protected override Vertex NextVertex(Vertex currentVertex)
         {
-            var index = UnityEngine.Random.Range(0, TargetVertex.Neighbors.Count);
-            return TargetVertex.Neighbors.ElementAt(index);
+            var index = UnityEngine.Random.Range(0, currentVertex.Neighbors.Count);
+            return currentVertex.Neighbors.ElementAt(index);
         }
     }
 }

--- a/Assets/Scripts/UI/Patrolling/VertexVisualizer.cs
+++ b/Assets/Scripts/UI/Patrolling/VertexVisualizer.cs
@@ -36,7 +36,7 @@ namespace Maes.UI.Patrolling
 
         public void OnMouseEnter()
         {
-            Tooltip.ShowTooltip_Static($"Visits: {VertexDetails.Vertex.NumberOfVisits}");
+            Tooltip.ShowTooltip_Static($"{VertexDetails.Vertex} Visits: {VertexDetails.Vertex.NumberOfVisits}");
         }
         public void OnMouseExit()
         {


### PR DESCRIPTION
Use the global patrolling map, so the robots know about the real idleness of all vertices.
Create a coordinator to coordinate which vertices robots occupy to avoid going to the same vertex.

Clean up the code in many places, to make it nicer on the slides.