### PR TITLE
Fix non deterministic behaviour when restarting a simulation

### DIFF
--- a/Assets/Scripts/ExperimentSimulations/AvariceExperiment.cs
+++ b/Assets/Scripts/ExperimentSimulations/AvariceExperiment.cs
@@ -134,7 +134,7 @@ namespace Maes.ExperimentSimulations
                                                                                     buildingConfig,
                                                                                     seed: 123,
                                                                                     numberOfRobots: robotCount,
-                                                                                    suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                                                    suggestedStartingPoint: null,
                                                                                     createAlgorithmDelegate: algorithm),
                                                                                 statisticsFileName: $"avarice-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                                 robotConstraints: constraint)

--- a/Assets/Scripts/ExperimentSimulations/ExampleProgram.cs
+++ b/Assets/Scripts/ExperimentSimulations/ExampleProgram.cs
@@ -138,7 +138,7 @@ namespace Maes.ExperimentSimulations
                                                                                  buildingConfig,
                                                                                  seed: 123,
                                                                                  numberOfRobots: robotCount,
-                                                                                 suggestedStartingPoint: new Vector2Int(random.Next(0, size), random.Next(0, size)),
+                                                                                 suggestedStartingPoint: null,
                                                                                  createAlgorithmDelegate: algorithm),
                                                                              statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-size-{size}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                              robotConstraints: robotConstraints)

--- a/Assets/Scripts/ExperimentSimulations/ExplorationExperimentBase.cs
+++ b/Assets/Scripts/ExperimentSimulations/ExplorationExperimentBase.cs
@@ -165,7 +165,7 @@ namespace Maes.ExperimentSimulations
                                                                                 buildingConfig,
                                                                                 seed: 123,
                                                                                 numberOfRobots: robotCount,
-                                                                                suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                                                suggestedStartingPoint: null,
                                                                                 createAlgorithmDelegate: algorithms[algorithmName]),
                                                                             statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                             robotConstraints: constraintsDict[constraintName])
@@ -180,9 +180,7 @@ namespace Maes.ExperimentSimulations
                                         buildingConfig,
                                         seed: 123,
                                         numberOfRobots: robotCount,
-                                        suggestedStartingPoint: new Vector2Int(
-                                            random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2),
-                                            random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                        suggestedStartingPoint: null,
                                         createAlgorithmDelegate: algorithms[algorithmName]),
                                     statisticsFileName:
                                     $"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
@@ -243,7 +241,7 @@ namespace Maes.ExperimentSimulations
                                                                                 buildingConfig,
                                                                                 seed: 123,
                                                                                 numberOfRobots: robotCount,
-                                                                                suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                                                suggestedStartingPoint: null,
                                                                                 createAlgorithmDelegate: algorithms[algorithmName]),
                                                                             statisticsFileName: $"{mapType}-{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                             robotConstraints: constraintsDict[constraintName])
@@ -257,7 +255,7 @@ namespace Maes.ExperimentSimulations
                                                     buildingConfig,
                                                     seed: 123,
                                                     numberOfRobots: robotCount,
-                                                    suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                    suggestedStartingPoint: null,
                                                     createAlgorithmDelegate: algorithms[algorithmName]),
                                                 statisticsFileName: $"{mapType}-{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                 robotConstraints: constraintsDict[constraintName]));

--- a/Assets/Scripts/ExperimentSimulations/ExplorationTimeoutTest.cs
+++ b/Assets/Scripts/ExperimentSimulations/ExplorationTimeoutTest.cs
@@ -146,7 +146,7 @@ namespace Maes.ExperimentSimulations
                                 buildingConfig,
                                 seed: 123,
                                 numberOfRobots: robotCount,
-                                suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                suggestedStartingPoint: null,
                                 createAlgorithmDelegate: algorithms[algorithmName]),
                             statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                             robotConstraints: constraintsDict[constraintName]));
@@ -160,7 +160,7 @@ namespace Maes.ExperimentSimulations
                                 buildingConfig,
                                 seed: 123,
                                 numberOfRobots: robotCount,
-                                suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                suggestedStartingPoint: null,
                                 createAlgorithmDelegate: algorithms[algorithmName]),
                             statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                             robotConstraints: constraintsDict[constraintName]));

--- a/Assets/Scripts/ExperimentSimulations/HenrikExample.cs
+++ b/Assets/Scripts/ExperimentSimulations/HenrikExample.cs
@@ -127,7 +127,7 @@ namespace Maes.ExperimentSimulations
                                                                              buildingConfig,
                                                                              seed: 123,
                                                                              numberOfRobots: robotCount,
-                                                                             suggestedStartingPoint: new Vector2Int(random.Next(0, size), random.Next(0, size)),
+                                                                             suggestedStartingPoint: null,
                                                                              createAlgorithmDelegate: algorithm),
                                                                          statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-size-{size}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                          robotConstraints: robotConstraints)

--- a/Assets/Scripts/ExperimentSimulations/MinotaurExperiments.cs
+++ b/Assets/Scripts/ExperimentSimulations/MinotaurExperiments.cs
@@ -133,7 +133,7 @@ namespace Maes.ExperimentSimulations
                                                                                  buildingConfig,
                                                                                  seed: 123,
                                                                                  numberOfRobots: robotCount,
-                                                                                 suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                                                 suggestedStartingPoint: null,
                                                                                  createAlgorithmDelegate: algorithm),
                                                                              statisticsFileName: $"minotaur-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                              robotConstraints: constraint)

--- a/Assets/Scripts/ExperimentSimulations/RandomReactiveExperiment.cs
+++ b/Assets/Scripts/ExperimentSimulations/RandomReactiveExperiment.cs
@@ -138,7 +138,7 @@ namespace Maes.ExperimentSimulations
                                                                                  buildingConfig,
                                                                                  seed: 123,
                                                                                  numberOfRobots: robotCount,
-                                                                                 suggestedStartingPoint: new Vector2Int(random.Next(-size / 2, size / 2), random.Next(-size / 2, size / 2)),
+                                                                                 suggestedStartingPoint: null,
                                                                                  createAlgorithmDelegate: algorithm),
                                                                              statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-size-{size}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                              robotConstraints: robotConstraints)

--- a/Assets/Scripts/ExperimentSimulations/TnfExperiments.cs
+++ b/Assets/Scripts/ExperimentSimulations/TnfExperiments.cs
@@ -134,7 +134,7 @@ namespace Maes.ExperimentSimulations
                                                                              buildingConfig,
                                                                              seed: 123,
                                                                              numberOfRobots: robotCount,
-                                                                             suggestedStartingPoint: new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)),
+                                                                             suggestedStartingPoint: null,
                                                                              createAlgorithmDelegate: algorithm),
                                                                          statisticsFileName: $"tnf-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                          robotConstraints: constraint)

--- a/Assets/Scripts/ExperimentSimulations/WallFollowerExperiment.cs
+++ b/Assets/Scripts/ExperimentSimulations/WallFollowerExperiment.cs
@@ -133,7 +133,7 @@ namespace Maes.ExperimentSimulations
                                                                                  buildingConfig,
                                                                                  seed: 123,
                                                                                  numberOfRobots: robotCount,
-                                                                                 suggestedStartingPoint: new Vector2Int(random.Next(-size / 2, size / 2), random.Next(-size / 2, size / 2)),
+                                                                                 suggestedStartingPoint: null,
                                                                                  createAlgorithmDelegate: algorithm),
                                                                              statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-size-{size}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                                                                              robotConstraints: robotConstraints)

--- a/Assets/Scripts/Map/RobotSpawners/RobotSpawner.cs
+++ b/Assets/Scripts/Map/RobotSpawners/RobotSpawner.cs
@@ -214,8 +214,12 @@ namespace Maes.Map.RobotSpawners
             var edgeTiles = FindEdgeTiles(possibleSpawnTiles, true);
             possibleSpawnTiles = possibleSpawnTiles.Except(edgeTiles).ToList();
 
-            // If no suggestions made, simply spawn around 0,0
-            suggestedStartingPoint ??= new Vector2Int(0, 0);
+            // If no suggestions made, simply spawn randomly
+            var random = new System.Random(seed);
+            var maxWidth = collisionMap.WidthInTiles / 2;
+            var maxHeight = collisionMap.HeightInTiles / 2;
+            suggestedStartingPoint ??= new Vector2Int(random.Next(-maxWidth, maxWidth), random.Next(-maxHeight, maxHeight));
+
             // Offset suggested starting point to map
             suggestedStartingPoint = new Vector2Int(suggestedStartingPoint.Value.x - (int)collisionMap.ScaledOffset.x,
                     suggestedStartingPoint.Value.y - (int)collisionMap.ScaledOffset.y);

--- a/Assets/Scripts/UI/RestartRemakeControllers/RestartRemakeController.cs
+++ b/Assets/Scripts/UI/RestartRemakeControllers/RestartRemakeController.cs
@@ -54,10 +54,7 @@ namespace Maes.UI.RestartRemakeControllers
             _createBatchButton = uiDocument.rootVisualElement.Q<Button>("CreateBatchButton");
 
             // TODO: What is the point of this panel?
-            // Why would you ever restart scenarios?
-            // It should all be deterministic.
             // 2 of the buttons don't even do anything.
-            // FIXME: !!!!! IT IS NOT DETERMINISTIC WHEN YOU RESTART SCENARIOS !!!!!
 
             _restartCurrentButton.RegisterCallback<ClickEvent>(RestartCurrentScenario);
             _restartAllButton.RegisterCallback<ClickEvent>(RestartAllScenarios);


### PR DESCRIPTION
Now the robots are spawned at the same spot when restarting the simulation

The SpawnRobotsTogether is now using a random starting point if a suggestedStartingPoint is not given. Most experiments used a random starting point, but generated a random starting point at each restart. This has been removed at moved into the SpawnRobotsTogether method, such that is gives a random starting point using the incoming seed, and ensure to start at the same random starting point. 
