### PR TITLE
Add sources to the patrolling algorithms

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
@@ -4,6 +4,10 @@ using Maes.Map;
 
 namespace Maes.Algorithms.Patrolling
 {
+    /// <summary>
+    /// Original implementation of the Conscientious Reactive Algorithm of https://doi.org/10.1007/3-540-36483-8_11.
+    /// Pseudocode can be found in another paper: https://doi.org/10.1080/01691864.2013.763722
+    /// </summary>
     public class ConscientiousReactiveAlgorithm : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Conscientious Reactive Algorithm";

--- a/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
@@ -7,7 +7,8 @@ using Random = System.Random;
 namespace Maes.Algorithms.Patrolling
 {
     /// <summary>
-    /// The random reactive patrolling algorithm from "Multi-Agent Movement Coordination in Patrolling", 2002
+    /// Original implementation of the Conscientious Reactive Algorithm of https://doi.org/10.1007/3-540-36483-8_11.
+    /// Pseudocode can be found in another paper: https://doi.org/10.1080/01691864.2013.763722
     /// </summary>
     public class RandomReactive : PatrollingAlgorithm
     {


### PR DESCRIPTION
I only added sources to the ones I'm sure of. I think we should do it for all of them. This way furture groups don't need to compare code to pseudocode to check which version of a patrolling algorithm we've implemented.