### PR TITLE
Test all patrolling algorithms

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -86,8 +86,6 @@ namespace Maes.Algorithms.Patrolling.Components
                 yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
             }
 
-            
-
             while (true)
             {
 

--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -86,6 +86,8 @@ namespace Maes.Algorithms.Patrolling.Components
                 yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
             }
 
+            
+
             while (true)
             {
 
@@ -95,7 +97,6 @@ namespace Maes.Algorithms.Patrolling.Components
 
                 // Tell PatrollingAlgorithm that we reached the vertex
                 _patrollingAlgorithm.OnReachTargetVertex(vertex, targetVertex);
-
                 var path = GetPathStepsToVertex(vertex, targetVertex);
                 vertex = targetVertex;
 

--- a/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
+++ b/Assets/Scripts/Map/RobotSpawners/PatrollingRobotSpawner.cs
@@ -22,10 +22,9 @@ namespace Maes.Map.RobotSpawners
         {
             var robot = base.CreateRobot(x, y, relativeSize, robotId, algorithm, collisionMap, seed);
 
+            algorithm.SetGlobalPatrollingMap(_patrollingMap);
             algorithm.SetPatrollingMap(_patrollingMap.Clone());
             algorithm.SubscribeOnReachVertex(_tracker.OnReachedVertex);
-
-            algorithm.SetGlobalPatrollingMap(_patrollingMap);
 
             return robot;
         }

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
@@ -16,7 +16,8 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
     public class PatrollingAlgorithmTest : MonoBehaviour
     {
         private MySimulator _maes;
-        private const int Seed = 12345;
+        private const int Seed = 1;
+        private const int MaxSimulatedLogicTicks = 250000;
 
         private PatrollingSimulation EnqueueCaveMapScenario(PatrollingAlgorithm algorithm, int seed = Seed)
         {
@@ -40,7 +41,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                         seed: seed,
                         numberOfRobots: robotCount,
                         spawnPositions: spawningPosList,
-                        createAlgorithmDelegate: (_) => new ConscientiousReactiveAlgorithm()),
+                        createAlgorithmDelegate: (_) => algorithm),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints, statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-RandomRobotSpawn")
             );
@@ -69,7 +70,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                         seed: seed,
                         numberOfRobots: robotCount,
                         spawnPositions: spawningPosList,
-                        createAlgorithmDelegate: (_) => new ConscientiousReactiveAlgorithm()),
+                        createAlgorithmDelegate: (_) => algorithm),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints, statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-RandomRobotSpawn")
             );
@@ -93,11 +94,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueCaveMapScenario(new ConscientiousReactiveAlgorithm());
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
 
         [Test(ExpectedResult = null)]
@@ -105,11 +106,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueBuildingMapScenario(new ConscientiousReactiveAlgorithm());
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
 
         [Test(ExpectedResult = null)]
@@ -117,11 +118,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueCaveMapScenario(new RandomReactive(Seed));
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
 
         [Test(ExpectedResult = null)]
@@ -129,11 +130,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueBuildingMapScenario(new RandomReactive(Seed));
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
 
         [Test(ExpectedResult = null)]
@@ -141,11 +142,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueCaveMapScenario(new CognitiveCoordinated());
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
 
         [Test(ExpectedResult = null)]
@@ -153,11 +154,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         {
             var simulation = EnqueueBuildingMapScenario(new CognitiveCoordinated());
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
-            while (!simulation.HasFinishedSim())
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
                 yield return null;
             }
-            Assert.True(simulation.HasFinishedSim());
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
         }
     }
 }


### PR DESCRIPTION
Last PR had a mistake. It always ran using CR algorithm, now it actually runs with each of the different algorithms.

- Cognitive Coordinated does not work. When two tests are run, the second fails giving an indexOutOfBounds exception. Update: I've fixed it, it works now.

- Also, the random reactive algorithm fails due to it being stuck.

Should this be merged or should the algos be fixed first?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a simulation tick limit to prevent tests from running indefinitely.
	- Updated test scenarios to use passed algorithms for improved execution flexibility.
	- Enhanced error messaging to notify when simulations exceed expected limits.
- **Improvements**
	- Streamlined pathfinding logic by removing unnecessary checks and directly utilizing the current vertex.
	- Optimized robot spawning logic by eliminating redundant method calls.
- **Style**
	- Minor whitespace adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->