### PR TITLE
Make PatrollingAlgorithm Component based

### DIFF
--- a/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/IPatrollingAlgorithm.cs
@@ -8,6 +8,9 @@ namespace Maes.Algorithms
     {
         string AlgorithmName { get; }
 
+        /// <summary>
+        /// Only to be used for visualization.
+        /// </summary>
         Vertex TargetVertex { get; }
 
         void SetPatrollingMap(PatrollingMap map);

--- a/Assets/Scripts/Algorithms/Patrolling/CognitiveCoordinated.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/CognitiveCoordinated.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using Maes.Algorithms.Patrolling.Components;
 using Maes.Map;
+using Maes.Robot;
 
 using UnityEngine;
 
 namespace Maes.Algorithms.Patrolling
 {
-    public class CognitiveCoordinated : PatrollingAlgorithm
+    public sealed class CognitiveCoordinated : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Cognitive Coordinated Algorithm";
         private List<Vertex> _currentPath = new();
@@ -26,6 +28,16 @@ namespace Maes.Algorithms.Patrolling
                 .AppendFormat("Last Vertex: {0}\n", _currentPath.Count > 0 ? _currentPath[^1].ToString() : "None");
         }
 
+        // Set by CreateComponents
+        private GoToNextVertexComponent _goToNextVertexComponent = null!;
+
+        protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
+        {
+            _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+
+            return new IComponent[] { _goToNextVertexComponent };
+        }
+
         public override void SetGlobalPatrollingMap(PatrollingMap globalMap)
         {
             base.SetGlobalPatrollingMap(globalMap);
@@ -39,7 +51,7 @@ namespace Maes.Algorithms.Patrolling
             Coordinator.ClearOccupiedVertices();
         }
 
-        protected override Vertex NextVertex(Vertex currentVertex)
+        private Vertex NextVertex(Vertex currentVertex)
         {
             // We have reached our target. Create a new path.
             if (_pathStep == _currentPath.Count)

--- a/Assets/Scripts/Algorithms/Patrolling/Components.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5e0bcfb91b8844ea9857ada0c13c848
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -1,0 +1,188 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: Mads Beyer Mogensen
+
+using System;
+using System.Collections.Generic;
+
+using Maes.Map;
+using Maes.Map.PathFinding;
+using Maes.Robot;
+using Maes.Robot.Task;
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.Components
+{
+    /// <summary>
+    /// This component moves the robot to the vertex specified by the algorithm.
+    /// When the vertex has been reached it gets the next vertex from the algorithm.
+    /// </summary>
+    public sealed class GoToNextVertexComponent : IComponent
+    {
+        // How close the robot has to get to a point before it has arrived.
+        private const float MinDistance = 0.25f;
+
+        // How small the angle to the target has to be before it is pointing in the direction.
+        private const float MinAngle = 1.5f;
+
+        private readonly NextVertexDelegate _nextVertexDelegate;
+        private readonly PatrollingAlgorithm _patrollingAlgorithm;
+        private readonly Robot2DController _controller;
+        private readonly PatrollingMap _patrollingMap;
+
+        /// <summary>
+        /// Delegate that specifies the next vertex to travel to.
+        /// </summary>
+        public delegate Vertex NextVertexDelegate(Vertex currentVertex);
+
+        /// <inheritdoc />
+        public int PreUpdateOrder { get; } = 0;
+
+        /// <inheritdoc />
+        public int PostUpdateOrder { get; } = 0;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="GoToNextVertexComponent"/>.
+        /// </summary>
+        /// <param name="nextVertexDelegate">The delegate that gets called to get the next vertex.</param>
+        /// <param name="patrollingAlgorithm">The patrolling algorithm.</param>
+        /// <param name="controller">The robot controller.</param>
+        /// <param name="patrollingMap">The patrolling map.</param>
+        public GoToNextVertexComponent(NextVertexDelegate nextVertexDelegate, PatrollingAlgorithm patrollingAlgorithm, Robot2DController controller, PatrollingMap patrollingMap)
+        {
+            _nextVertexDelegate = nextVertexDelegate;
+            _patrollingAlgorithm = patrollingAlgorithm;
+            _controller = controller;
+            _patrollingMap = patrollingMap;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<ComponentWaitForCondition> PreUpdateLogic()
+        {
+            // Go to the initial vertex.
+            var vertex = GetClosestVertex();
+            while (GetRelativePositionTo(vertex.Position).Distance > MinDistance)
+            {
+                _controller.PathAndMoveTo(vertex.Position, dependOnBrokenBehaviour: false);
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+            }
+
+            while (true)
+            {
+
+                // Follow the path.
+                // Go to the next vertex
+                var targetVertex = _nextVertexDelegate(vertex);
+
+                // Tell PatrollingAlgorithm that we reached the vertex
+                _patrollingAlgorithm.OnReachTargetVertex(vertex, targetVertex);
+
+                var path = GetPathStepsToVertex(vertex, targetVertex);
+                vertex = targetVertex;
+
+
+                // Move to the start of the path
+                foreach (var condition in MoveToPosition(path.Peek().Start))
+                {
+                    yield return condition;
+                }
+
+                // Move to the end of each path
+                while (path.TryDequeue(out var pathStep))
+                {
+                    foreach (var condition in MoveToPosition(pathStep.End))
+                    {
+                        yield return condition;
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<ComponentWaitForCondition> PostUpdateLogic()
+        {
+            while (true)
+            {
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
+            }
+        }
+
+        /// <summary>
+        /// Gets the vertex closest to the robot.
+        /// </summary>
+        /// <remarks>
+        /// TODO: This does not take walls into account so it might not pick the best waypoint.
+        /// </remarks>
+        /// <returns>The closest vertex.</returns>
+        private Vertex GetClosestVertex()
+        {
+            var vertices = _patrollingMap.Vertices;
+
+            var position = _controller.GetSlamMap().GetCoarseMap().GetCurrentPosition(dependOnBrokenBehavior: false);
+            var closestVertex = vertices[0];
+            var closestDistance = Vector2Int.Distance(position, closestVertex.Position);
+            foreach (var vertex in vertices.AsSpan(1))
+            {
+                var distance = Vector2Int.Distance(position, vertex.Position);
+                if (distance < closestDistance)
+                {
+                    closestDistance = distance;
+                    closestVertex = vertex;
+                }
+            }
+
+            return closestVertex;
+        }
+
+
+        private IEnumerable<ComponentWaitForCondition> MoveToPosition(Vector2Int target)
+        {
+            while (true)
+            {
+                yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, shouldContinue: false);
+
+                var relativePosition = GetRelativePositionTo(target);
+                if (relativePosition.Distance <= MinDistance)
+                {
+                    yield break;
+                }
+
+
+                if (Math.Abs(relativePosition.RelativeAngle) > MinAngle)
+                {
+                    _controller.Rotate(relativePosition.RelativeAngle);
+                }
+                else
+                {
+                    _controller.Move(relativePosition.Distance);
+                }
+            }
+        }
+
+        private RelativePosition GetRelativePositionTo(Vector2Int position)
+        {
+            return _controller.SlamMap.CoarseMap.GetTileCenterRelativePosition(position, dependOnBrokenBehaviour: false);
+        }
+
+        private Queue<PathStep> GetPathStepsToVertex(Vertex currentVertex, Vertex targetVertex)
+        {
+            return new Queue<PathStep>(_patrollingMap.Paths[(currentVertex.Id, targetVertex.Id)]);
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f1a329c4d851a62bb38870880d49dfc

--- a/Assets/Scripts/Algorithms/Patrolling/Components/IComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/IComponent.cs
@@ -1,0 +1,69 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: Mads Beyer Mogensen
+
+using System.Collections.Generic;
+
+using Maes.Robot.Task;
+
+namespace Maes.Algorithms.Patrolling.Components
+{
+    /// <summary>
+    /// A component that can be used in <see cref="PatrollingAlgorithm"/> to add functionality.
+    /// </summary>
+    public interface IComponent
+    {
+        IEnumerable<ComponentWaitForCondition> PreUpdateLogic();
+
+        IEnumerable<ComponentWaitForCondition> PostUpdateLogic();
+
+        /// <summary>
+        /// The order the component's <see cref="PreUpdateLogic"/> method is executed in comparison to the other components.
+        /// </summary>
+        int PreUpdateOrder { get; }
+
+        /// <summary>
+        /// The order the component's <see cref="PostUpdateLogic"/> method is executed in comparison to the other components.
+        /// </summary>
+        int PostUpdateOrder { get; }
+    }
+
+    public readonly struct ComponentWaitForCondition
+    {
+        public WaitForCondition Condition { get; }
+
+        public bool ShouldContinue { get; }
+
+        // Do not use this!
+        public ComponentWaitForCondition(WaitForCondition waitForCondition, bool shouldContinue)
+        {
+            Condition = waitForCondition;
+            ShouldContinue = shouldContinue;
+        }
+
+        public static ComponentWaitForCondition WaitForLogicTicks(int logicTicks, bool shouldContinue)
+        {
+            return new ComponentWaitForCondition(WaitForCondition.WaitForLogicTicks(logicTicks), shouldContinue);
+        }
+
+        public static ComponentWaitForCondition WaitForRobotStatus(RobotStatus status, bool shouldContinue)
+        {
+            return new ComponentWaitForCondition(WaitForCondition.WaitForRobotStatus(status), shouldContinue);
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/Components/IComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/IComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3695bf108394f926194deab725789dc7

--- a/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 
+using Maes.Algorithms.Patrolling.Components;
 using Maes.Map;
+using Maes.Robot;
 
 namespace Maes.Algorithms.Patrolling
 {
@@ -8,11 +10,21 @@ namespace Maes.Algorithms.Patrolling
     /// Original implementation of the Conscientious Reactive Algorithm of https://doi.org/10.1007/3-540-36483-8_11.
     /// Pseudocode can be found in another paper: https://doi.org/10.1080/01691864.2013.763722
     /// </summary>
-    public class ConscientiousReactiveAlgorithm : PatrollingAlgorithm
+    public sealed class ConscientiousReactiveAlgorithm : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Conscientious Reactive Algorithm";
 
-        protected override Vertex NextVertex(Vertex currentVertex)
+        // Set by CreateComponents
+        private GoToNextVertexComponent _goToNextVertexComponent = null!;
+
+        protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
+        {
+            _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+
+            return new IComponent[] { _goToNextVertexComponent };
+        }
+
+        private static Vertex NextVertex(Vertex currentVertex)
         {
             return currentVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
         }

--- a/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
@@ -27,7 +27,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using Maes.Algorithms.Patrolling.Components;
 using Maes.Map;
+using Maes.Robot;
 
 using UnityEngine;
 
@@ -36,15 +38,25 @@ namespace Maes.Algorithms.Patrolling
     /// <summary>
     /// Original implementation of the Heuristic Conscientious Reactive Algorithm of https://repositorio.ufpe.br/handle/123456789/2474.
     /// Pseudocode can be found in another paper: https://doi.org/10.1080/01691864.2013.763722
-    // Heuristic: The vertex with the lowest idleness and distance estimation
+    /// Heuristic: The vertex with the lowest idleness and distance estimation
     /// </summary>
-    public class HeuristicConscientiousReactiveAlgorithm : PatrollingAlgorithm
+    public sealed class HeuristicConscientiousReactiveAlgorithm : PatrollingAlgorithm
     {
         public override string AlgorithmName => "Heuristic Conscientious Reactive Algorithm";
 
+        // Set by CreateComponents
+        private GoToNextVertexComponent _goToNextVertexComponent = null!;
+
+        protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
+        {
+            _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+
+            return new IComponent[] { _goToNextVertexComponent };
+        }
+
         public delegate float DistanceEstimator(Vector2Int position);
 
-        protected override Vertex NextVertex(Vertex currentVertex)
+        private Vertex NextVertex(Vertex currentVertex)
         {
             Debug.Log($"Current vertex {currentVertex.Id}");
             // Calculate the normalized idleness of the neighbors

--- a/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 
+using Maes.Algorithms.Patrolling.Components;
 using Maes.Map;
+using Maes.Robot;
 
 using Random = System.Random;
 
@@ -10,7 +12,7 @@ namespace Maes.Algorithms.Patrolling
     /// Original implementation of the Conscientious Reactive Algorithm of https://doi.org/10.1007/3-540-36483-8_11.
     /// Pseudocode can be found in another paper: https://doi.org/10.1080/01691864.2013.763722
     /// </summary>
-    public class RandomReactive : PatrollingAlgorithm
+    public sealed class RandomReactive : PatrollingAlgorithm
     {
         private readonly Random _random;
 
@@ -21,7 +23,17 @@ namespace Maes.Algorithms.Patrolling
 
         public override string AlgorithmName => "Random Reactive Algorithm";
 
-        protected override Vertex NextVertex(Vertex currentVertex)
+        // Set by CreateComponents
+        private GoToNextVertexComponent _goToNextVertexComponent = null!;
+
+        protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
+        {
+            _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+
+            return new IComponent[] { _goToNextVertexComponent };
+        }
+
+        private Vertex NextVertex(Vertex currentVertex)
         {
             var index = _random.Next(currentVertex.Neighbors.Count);
             return currentVertex.Neighbors.ElementAt(index);


### PR DESCRIPTION
Components have two methods `PreUpdate` and `PostUpdate`.

`PreUpdate` is called before the algorithm's `Update` method is called.
Here the component do stuff such as move the robot about.
It can also wait for certain conditions such as a robot status or waiting for x ticks.
Likewise `PostUpdate` is run after the algorithm's `Update` method is called.

`PreUpdate` and `PostUpdate` are enumerables so that we can implement statemachines without having to keep track of the machine's state manually.

They return a wrapper around `WaitForCondition` with an additional bool `ShouldContinue`.
If `ShouldContinue` is true the next component in the chain is run, and eventually `Update` is run.

If `ShouldContinue` is false the chain stops executing there and next tick `PreUpdate` is called again.
Here `Update` and `PostUpdate` is not called.
This allows the components to do exceptional things such as collision avoidance, while not being trampled over by the next components.

Our tests seem to be shit as we have no collision avoidance right now.
Are there really no problems having no collision avoidance? I really doubt it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a modular navigation component for patrolling operations to streamline pathfinding.

- **Refactor**
  - Enhanced several patrol algorithms for better modularity, encapsulation, and overall stability.
  - Updated access levels and internal logic to ensure more consistent behavior.
  - Adjusted the visualization mode by temporarily disabling target point display to align with the updated algorithm design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->