### PR TITLE
CollisionRecoveryComponent

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/CognitiveCoordinated.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/CognitiveCoordinated.cs
@@ -30,12 +30,14 @@ namespace Maes.Algorithms.Patrolling
 
         // Set by CreateComponents
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
+        private CollisionRecoveryComponent _collisionRecoveryComponent = null!;
 
         protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
         {
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+            _collisionRecoveryComponent = new CollisionRecoveryComponent(controller, _goToNextVertexComponent);
 
-            return new IComponent[] { _goToNextVertexComponent };
+            return new IComponent[] { _goToNextVertexComponent, _collisionRecoveryComponent };
         }
 
         public override void SetGlobalPatrollingMap(PatrollingMap globalMap)

--- a/Assets/Scripts/Algorithms/Patrolling/Components/CollisionRecoveryComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/CollisionRecoveryComponent.cs
@@ -1,0 +1,88 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: Puvikaran Santhirasegaram
+
+using System.Collections.Generic;
+
+using Maes.Robot;
+using Maes.Robot.Task;
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.Components
+{
+    public class CollisionRecoveryComponent : IComponent
+    {
+        // How close the robot has to get to a point before it has arrived.
+        private const float MinDistance = 0.25f;
+
+        private readonly Robot2DController _controller;
+        private readonly IMovementComponent _movementComponent;
+
+        public int PreUpdateOrder => -100;
+        public int PostUpdateOrder => -100;
+
+        public CollisionRecoveryComponent(Robot2DController controller, IMovementComponent movementComponent)
+        {
+            _controller = controller;
+            _movementComponent = movementComponent;
+        }
+
+        public IEnumerable<ComponentWaitForCondition> PreUpdateLogic()
+        {
+            while (true)
+            {
+                if (_controller.IsCurrentlyColliding)
+                {
+                    _controller.StopCurrentTask();
+                    yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, false);
+
+                    _controller.Move(1.0f, reverse: true);
+                    yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, false);
+
+                    if (_controller.IsCurrentlyColliding)
+                    {
+                        _controller.Move(1.0f, reverse: false);
+                        yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, false);
+                    }
+
+                    while (GetRelativePositionTo(_movementComponent.TargetPosition).Distance > MinDistance)
+                    {
+                        _controller.PathAndMoveTo(_movementComponent.TargetPosition, dependOnBrokenBehaviour: false);
+                        yield return ComponentWaitForCondition.WaitForLogicTicks(1, false);
+                    }
+                }
+
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, true);
+            }
+        }
+
+        public IEnumerable<ComponentWaitForCondition> PostUpdateLogic()
+        {
+            while (true)
+            {
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
+            }
+        }
+
+        private RelativePosition GetRelativePositionTo(Vector2Int position)
+        {
+            return _controller.SlamMap.CoarseMap.GetTileCenterRelativePosition(position, dependOnBrokenBehaviour: false);
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/Components/CollisionRecoveryComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/CollisionRecoveryComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a44b7e3197b64242bb7ebd7300297118
+timeCreated: 1741258851

--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -34,7 +34,7 @@ namespace Maes.Algorithms.Patrolling.Components
     /// This component moves the robot to the vertex specified by the algorithm.
     /// When the vertex has been reached it gets the next vertex from the algorithm.
     /// </summary>
-    public sealed class GoToNextVertexComponent : IComponent
+    public sealed class GoToNextVertexComponent : IMovementComponent
     {
         // How close the robot has to get to a point before it has arrived.
         private const float MinDistance = 0.25f;
@@ -46,6 +46,7 @@ namespace Maes.Algorithms.Patrolling.Components
         private readonly PatrollingAlgorithm _patrollingAlgorithm;
         private readonly Robot2DController _controller;
         private readonly PatrollingMap _patrollingMap;
+        public Vector2Int TargetPosition { get; private set; }
 
         /// <summary>
         /// Delegate that specifies the next vertex to travel to.
@@ -78,6 +79,7 @@ namespace Maes.Algorithms.Patrolling.Components
         {
             // Go to the initial vertex.
             var vertex = GetClosestVertex();
+            TargetPosition = vertex.Position;
             while (GetRelativePositionTo(vertex.Position).Distance > MinDistance)
             {
                 _controller.PathAndMoveTo(vertex.Position, dependOnBrokenBehaviour: false);
@@ -155,6 +157,7 @@ namespace Maes.Algorithms.Patrolling.Components
 
         private IEnumerable<ComponentWaitForCondition> MoveToPosition(Vector2Int target)
         {
+            TargetPosition = target;
             while (true)
             {
                 yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, shouldContinue: false);

--- a/Assets/Scripts/Algorithms/Patrolling/Components/IMovementComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/IMovementComponent.cs
@@ -1,0 +1,30 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors:
+// Puvikaran Santhirasegaram
+// Mads Beyer Mogensen
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.Components
+{
+    public interface IMovementComponent : IComponent
+    {
+        public Vector2Int TargetPosition { get; }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/Components/IMovementComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/IMovementComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 81a141629cf44118965ecb2f009c2cb9
+timeCreated: 1741263460

--- a/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
@@ -16,12 +16,14 @@ namespace Maes.Algorithms.Patrolling
 
         // Set by CreateComponents
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
+        private CollisionRecoveryComponent _collisionRecoveryComponent = null!;
 
         protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
         {
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+            _collisionRecoveryComponent = new CollisionRecoveryComponent(controller, _goToNextVertexComponent);
 
-            return new IComponent[] { _goToNextVertexComponent };
+            return new IComponent[] { _goToNextVertexComponent, _collisionRecoveryComponent };
         }
 
         private static Vertex NextVertex(Vertex currentVertex)

--- a/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
@@ -46,12 +46,14 @@ namespace Maes.Algorithms.Patrolling
 
         // Set by CreateComponents
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
+        private CollisionRecoveryComponent _collisionRecoveryComponent = null!;
 
         protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
         {
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+            _collisionRecoveryComponent = new CollisionRecoveryComponent(controller, _goToNextVertexComponent);
 
-            return new IComponent[] { _goToNextVertexComponent };
+            return new IComponent[] { _goToNextVertexComponent, _collisionRecoveryComponent };
         }
 
         public delegate float DistanceEstimator(Vector2Int position);

--- a/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/RandomReactive.cs
@@ -25,12 +25,14 @@ namespace Maes.Algorithms.Patrolling
 
         // Set by CreateComponents
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
+        private CollisionRecoveryComponent _collisionRecoveryComponent = null!;
 
         protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
         {
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap);
+            _collisionRecoveryComponent = new CollisionRecoveryComponent(controller, _goToNextVertexComponent);
 
-            return new IComponent[] { _goToNextVertexComponent };
+            return new IComponent[] { _goToNextVertexComponent, _collisionRecoveryComponent };
         }
 
         private Vertex NextVertex(Vertex currentVertex)


### PR DESCRIPTION

The previous collision recovery is implemented again and moved to a separate component.

The robot simply reverse 1 meter if it is colliding, and then using the PathAndMoveTo implementation in the Robot2DController.

It requires the GoToNextVertexComponent, such that it can continue from the current path step, and ones it reaches that path step it can continue from where it left. Therefore, GoToNextVertexComponent has a extra field called MovingTo, that identifies where the robot is moving to. Initially, the "moving to" will be set to the closest vertex, otherwise it will be the path steps.

When running the current experiment of random reactive in the main branch. the robot is colliding into a wall in the second scenario, but after enable the CollisionRecoveryComponent it runs smooth. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced collision recovery has been integrated across multiple navigation and reactive algorithms, improving operational safety.
  - Real-time target tracking functionality has been introduced, providing clearer insights into current movement goals.

- **Refactor**
  - Adjustments have been made to expose key movement data, streamlining integration with the new collision recovery enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->