### PR TITLE
Remove this[x,y] from Bitmap

### DIFF
--- a/Assets/Scripts/Map/CoarseGrainedMap.cs
+++ b/Assets/Scripts/Map/CoarseGrainedMap.cs
@@ -157,7 +157,7 @@ namespace Maes.Map
         public bool IsTileExplored(Vector2Int localCoordinate)
         {
             AssertWithinBounds(localCoordinate);
-            return _tilesCoveredStatus[localCoordinate.x, localCoordinate.y];
+            return _tilesCoveredStatus.Contains(localCoordinate.x, localCoordinate.y);
         }
 
         // Sets the data at the given tile, overwriting any existing data object if present
@@ -557,7 +557,7 @@ namespace Maes.Map
                 return true;
             }
 
-            return (!_tilesCoveredStatus[coordinate.x, coordinate.y]) && GetSlamTileStatuses(coordinate).All(status => status != SlamMap.SlamTileStatus.Solid);
+            return (!_tilesCoveredStatus.Contains(coordinate.x, coordinate.y)) && GetSlamTileStatuses(coordinate).All(status => status != SlamMap.SlamTileStatus.Solid);
         }
 
         private SlamMap.SlamTileStatus[] GetSlamTileStatuses(Vector2Int coordinate)

--- a/Assets/Scripts/Utilities/Bitmap.cs
+++ b/Assets/Scripts/Utilities/Bitmap.cs
@@ -197,13 +197,6 @@ namespace Maes.Utilities
             Unset((x - XStart) * Height + (y - YStart));
         }
 
-        public bool this[int x, int y]
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get =>
-                Contains(x, y);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(Vector2Int point)
         {

--- a/Assets/Scripts/Utilities/Files/SaveMapAsImage.cs
+++ b/Assets/Scripts/Utilities/Files/SaveMapAsImage.cs
@@ -13,7 +13,7 @@ namespace Maes.Utilities.Files
             {
                 for (var y = 0; y < map.Height; y++)
                 {
-                    if (map[x, y])
+                    if (map.Contains(x, y))
                     {
                         texture.SetPixel(x, y, Color.blue);
                     }

--- a/Assets/Scripts/Utilities/MapUtilities.cs
+++ b/Assets/Scripts/Utilities/MapUtilities.cs
@@ -55,7 +55,7 @@ namespace Maes.Utilities
         {
             return pos.x >= 0 && pos.x < map.Width &&
                    pos.y >= 0 && pos.y < map.Height &&
-                   !map[pos.x, pos.y]; // true if the position is not a wall
+                   !map.Contains(pos.x, pos.y); // true if the position is not a wall
         }
 
         private static readonly Vector2Int[] Directions = new Vector2Int[]


### PR DESCRIPTION
Use Contains instead which is used much more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined how map areas are recognized for exploration and movement by transitioning to membership checks.
  - Updated the image-saving process for accurate visual representation of map features by using a method to check point presence.
  - Removed direct indexing methods for checking point containment in the bitmap, enhancing clarity in map operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->