### PR TITLE
added map offset to exploration

### DIFF
--- a/Assets/Scripts/UI/Visualizers/Exploration/ExplorationVisualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Exploration/ExplorationVisualizer.cs
@@ -25,6 +25,8 @@ using Maes.Statistics;
 
 using UnityEngine;
 
+using Maes.Map;
+
 namespace Maes.UI.Visualizers.Exploration
 {
     public class ExplorationVisualizer : Visualizer
@@ -34,6 +36,13 @@ namespace Maes.UI.Visualizers.Exploration
         public static readonly Color32 SlamSeenColor = new(50, 120, 180, 255);
         public static readonly Color32 WarmColor = new(200, 60, 60, 255);
         public static readonly Color32 ColdColor = new(50, 120, 180, 255);
+        
+        public override void SetSimulationMap(SimulationMap<Cell> newMap)
+        {
+            transform.position = newMap.ScaledOffset + new Vector2(0.5f, 0.5f); //fixing offset
+
+            base.SetSimulationMap(newMap);
+        }
 
         protected override Color32 InitializeCellColor(Cell cell)
         {

--- a/Assets/Scripts/UI/Visualizers/Exploration/ExplorationVisualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Exploration/ExplorationVisualizer.cs
@@ -21,11 +21,10 @@
 
 using System.Collections.Generic;
 
+using Maes.Map;
 using Maes.Statistics;
 
 using UnityEngine;
-
-using Maes.Map;
 
 namespace Maes.UI.Visualizers.Exploration
 {
@@ -36,10 +35,11 @@ namespace Maes.UI.Visualizers.Exploration
         public static readonly Color32 SlamSeenColor = new(50, 120, 180, 255);
         public static readonly Color32 WarmColor = new(200, 60, 60, 255);
         public static readonly Color32 ColdColor = new(50, 120, 180, 255);
-        
+
         public override void SetSimulationMap(SimulationMap<Cell> newMap)
         {
-            transform.position = newMap.ScaledOffset + new Vector2(0.5f, 0.5f); //fixing offset
+            //fixing map offset, but can't find why it needs 0.5 on both axes (hack)
+            transform.position = newMap.ScaledOffset + new Vector2(0.5f, 0.5f);
 
             base.SetSimulationMap(newMap);
         }


### PR DESCRIPTION
Fixed the visualisation of the exploration map by adding the offset.

But I can't figure out why it needs to add 0.5 to both axes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced simulation map functionality that automatically adjusts visual alignment based on offset data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->