### PR TITLE
Update heuristic concientious reactive

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/PatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/PatrollingAlgorithm.cs
@@ -20,7 +20,7 @@ namespace Maes.Algorithms.Patrolling
         private PatrollingMap _globalMap = null!;
 
         // Set by SetPatrollingMap
-        private PatrollingMap _patrollingMap = null!;
+        protected PatrollingMap _patrollingMap = null!;
 
         // Set by SetController
         protected Robot2DController _controller = null!;


### PR DESCRIPTION
It now uses the actual paths instead of finding paths each time to use for estimations.
This is because the Astar algorithms is broken. It does not return any paths. Here is a case where the astar fails/returns null:
![image](https://github.com/user-attachments/assets/42521580-451a-4d21-94e0-92dad6f39973)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the navigation and patrolling logic by refining the distance calculation process, resulting in more accurate and reliable routing.
  - Integrated more descriptive feedback when a valid path isn’t available.
  - Updated internal configuration settings to boost flexibility and maintainability for future navigation enhancements.
  - Improved accessibility of the patrolling map for derived classes, enhancing extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->