### PR TITLE
Heuristic cr follow pseudocode

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
@@ -68,10 +68,10 @@ namespace Maes.Algorithms.Patrolling
 
             // Calculate the normalized distance estimation of the neighbors
             var normalizedDistances = CalculateNormalizedDistance(currentVertex, ActualDistanceMethod);
-            var result = UtilityFunction(normalizedIdleness, normalizedDistances);
-            var maxUtilityValue = result.Select(i => i.Value).Min();
-            result = result.Where(i => i.Value == maxUtilityValue);
-            var nextVertex = result.ElementAt(_random.Next(result.Count())).Vertex;
+            var bestVertices = UtilityFunction(normalizedIdleness, normalizedDistances);
+            var minUtilityValue = bestVertices.Select(i => i.Value).Min();
+            bestVertices = bestVertices.Where(i => i.Value == minUtilityValue);
+            var nextVertex = bestVertices.ElementAt(_random.Next(bestVertices.Count())).Vertex;
             Debug.Log($"Next vertex {nextVertex.Id}, with neighbours: {string.Join(", ", nextVertex.Neighbors.Select(x => x.Id))}");
             return nextVertex;
         }

--- a/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
@@ -42,13 +42,18 @@ namespace Maes.Algorithms.Patrolling
     /// </summary>
     public sealed class HeuristicConscientiousReactiveAlgorithm : PatrollingAlgorithm
     {
+        public HeuristicConscientiousReactiveAlgorithm(int randomSeed = 0)
+        {
+            _random = new(randomSeed);
+        }
+        private readonly int _randomSeed;
         public override string AlgorithmName => "Heuristic Conscientious Reactive Algorithm";
 
         // Set by CreateComponents
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
         private CollisionRecoveryComponent _collisionRecoveryComponent = null!;
 
-        private readonly System.Random _random = new(0);
+        private readonly System.Random _random;
 
         protected override IComponent[] CreateComponents(Robot2DController controller, PatrollingMap patrollingMap)
         {

--- a/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HeuristicConscientiousReactive.cs
@@ -46,7 +46,6 @@ namespace Maes.Algorithms.Patrolling
         {
             _random = new(randomSeed);
         }
-        private readonly int _randomSeed;
         public override string AlgorithmName => "Heuristic Conscientious Reactive Algorithm";
 
         // Set by CreateComponents

--- a/Assets/Scripts/Experiments/Patrolling/HeuristicConscientiousReactiveExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HeuristicConscientiousReactiveExperiment.cs
@@ -94,7 +94,7 @@ namespace Maes.Experiments.Patrolling
                         seed: 123,
                         numberOfRobots: robotCount,
                         spawnPositions: spawningPosList,
-                        createAlgorithmDelegate: (_) => new HeuristicConscientiousReactiveAlgorithm()),
+                        createAlgorithmDelegate: (randomSeed) => new HeuristicConscientiousReactiveAlgorithm(randomSeed)),
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                     robotConstraints: robotConstraints
                 )
@@ -111,7 +111,7 @@ namespace Maes.Experiments.Patrolling
                         seed: 123,
                         numberOfRobots: robotCount,
                         spawnPositions: spawningPosList,
-                        createAlgorithmDelegate: (_) => new HeuristicConscientiousReactiveAlgorithm()),
+                        createAlgorithmDelegate: (randomSeed) => new HeuristicConscientiousReactiveAlgorithm(randomSeed)),
                     statisticsFileName: $"{algoName}-seed-{mapConfig2.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
                     robotConstraints: robotConstraints
                 )

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
@@ -114,6 +114,32 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         }
 
         [Test(ExpectedResult = null)]
+        public IEnumerator Test_HeuristicConscientiousReactive_CaveMap()
+        {
+            var simulation = EnqueueCaveMapScenario(new HeuristicConscientiousReactiveAlgorithm());
+            _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
+            {
+                yield return null;
+            }
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator Test_HeuristicConscientiousReactive_BuildingMap()
+        {
+            var simulation = EnqueueBuildingMapScenario(new HeuristicConscientiousReactiveAlgorithm());
+            _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
+            while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
+            {
+                yield return null;
+            }
+            Assert.True(simulation.HasFinishedSim(), $"Simulation did not finish under {MaxSimulatedLogicTicks} ticks, indicating the robot is stuck.");
+        }
+
+
+
+        [Test(ExpectedResult = null)]
         public IEnumerator Test_RandomReactive_CaveMap()
         {
             var simulation = EnqueueCaveMapScenario(new RandomReactive(Seed));

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
@@ -116,7 +116,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         [Test(ExpectedResult = null)]
         public IEnumerator Test_HeuristicConscientiousReactive_CaveMap()
         {
-            var simulation = EnqueueCaveMapScenario(new HeuristicConscientiousReactiveAlgorithm());
+            var simulation = EnqueueCaveMapScenario(new HeuristicConscientiousReactiveAlgorithm(Seed));
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
             while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {
@@ -128,7 +128,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
         [Test(ExpectedResult = null)]
         public IEnumerator Test_HeuristicConscientiousReactive_BuildingMap()
         {
-            var simulation = EnqueueBuildingMapScenario(new HeuristicConscientiousReactiveAlgorithm());
+            var simulation = EnqueueBuildingMapScenario(new HeuristicConscientiousReactiveAlgorithm(Seed));
             _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
             while (!simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
             {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9483aec8-baef-4c88-8d2b-76561ac467a7)
By choosing a random one when they score the same value it no longer gets stuck. :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a constructor for the patrolling algorithm, allowing for customizable random seed initialization.
	- Enhanced the algorithm's logic to select the next vertex based on minimum utility values, improving decision-making.
	- Updated robot spawning logic to utilize customizable random seed values for different scenarios.

- **Tests**
	- Introduced new simulation tests for cave and building scenarios to verify successful completion of routing without stalling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->