### PR TITLE
Bugfix: Don't set mesh render if no vertex is selected

### DIFF
--- a/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
@@ -273,12 +273,12 @@ namespace Maes.Statistics.Trackers
 
         public void ShowCommunicationZone()
         {
-            _visualizer.meshRenderer.enabled = true;
             if (_selectedVertex == null)
             {
                 Debug.Log("Cannot show communication zone when no vertex is selected");
                 return;
             }
+            _visualizer.meshRenderer.enabled = true;
             SetVisualizationMode(new CommunicationZoneVisualizationMode(_visualizer, _selectedVertex.VertexDetails.Vertex.Id));
         }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3b86434b-4f8f-4567-8781-b2b157f50042)
No vertex selected. Click the communication zone button. There is a debug log about how no vertex has been selected. But, the mesh render is enabled making it look like above, even when the UI says we are in "none" mode (which we are actually not). But, when clicking the none button, the mesh render is disabled, and everything is fine.

Even more fun happens when we select waypoint LOS mode. Then click none. Then click communication zone mode. The UI says we are in none mode, since we have not selected a waypoint. But the mesh render now displays as if we are in waypoint LOS mode:
![image](https://github.com/user-attachments/assets/9f67289a-fd5f-4399-9696-676c6780c8a4)
