### PR TITLE
Filter out duplicate colors before coloring the vertex

### DIFF
--- a/Assets/Scripts/UI/Visualizers/Patrolling/VertexVisualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VertexVisualizer.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using Maes.Statistics.Trackers;
 using Maes.Utilities;
 
@@ -39,7 +41,7 @@ namespace Maes.UI.Visualizers.Patrolling
                 SetWaypointColor(colors[0]);
             }
 
-            meshFilter.mesh = VertexColorMeshVisualizer.GenerateMeshMultipleColor(colors);
+            meshFilter.mesh = VertexColorMeshVisualizer.GenerateMeshMultipleColor(colors.Distinct().ToArray());
         }
 
         public void OnPointerClick(PointerEventData eventData)


### PR DESCRIPTION
This PR ensure that when a vertex is colored with multiple colors, then only unique colors are shown. Meaning, if we have two green and one yellow, then in the vertex there is one row green and the other row is yellow, instead of two green rows and one yellow row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the visual display by refining the color processing logic so that duplicate colors are filtered out before generating visual elements. This update ensures a more consistent and clear presentation in the visualizer component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->