### PR TITLE
Refactor selected-robot-communication-visualizer

### DIFF
--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
@@ -14,12 +14,14 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         private readonly MonaRobot _robot;
         private readonly SimulationMap<Tile> _simulationMap;
         private HashSet<int> _triangleIndexes;
+        private Vector2Int _lastPosition;
 
         public SelectedRobotCommunicationRangeVisualizationMode(MonaRobot robot, SimulationMap<Tile> simulationMap)
         {
             _robot = robot;
             _simulationMap = simulationMap;
             _triangleIndexes = new HashSet<int>();
+            _lastPosition = new Vector2Int(int.MaxValue, int.MaxValue);
         }
 
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
@@ -31,8 +33,15 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         // Note: This is a debug feature, so performance is not critical.
         private void UpdateMapColor(PatrollingVisualizer visualizer)
         {
-            _triangleIndexes = new HashSet<int>();
             var position = _robot.Controller.SlamMap.CoarseMap.GetCurrentPosition();
+            // Communication is based on the tile the robot is on,
+            // so if the robot hasn't moved to a new tile we don't need to update the map.
+            if (position == _lastPosition)
+            {
+                return;
+            }
+
+            _triangleIndexes = new HashSet<int>();
             var communicationRangeBitmap = _robot.Controller.CommunicationManager.CalculateCommunicationZone(position);
             var cellIndexTriangleIndexes = _simulationMap.CellIndexToTriangleIndexes();
             foreach (var tile in communicationRangeBitmap)
@@ -41,6 +50,7 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
                 _triangleIndexes.UnionWith(cellIndexTriangleIndexes[index]);
             }
             visualizer.SetAllColors(CellIndexToColor);
+            _lastPosition = position;
         }
 
         private Color32 CellIndexToColor(int cellIndex)


### PR DESCRIPTION
If the robot hasn't moved to a different tile, don't update the map wrt. communication range, since the communication range is tile based.

Now it is just a little laggy on 1x speed. Before it was completely unresponsive...