### PR TITLE
Refactor visualizer for bitmaps

### DIFF
--- a/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
@@ -273,7 +273,7 @@ namespace Maes.Statistics.Trackers
 
             _visualizer.meshRenderer.enabled = true;
             SetVisualizationMode(
-                new CommunicationZoneVisualizationMode(_visualizer, _selectedVertex.VertexDetails.Vertex.Id));
+                new CommunicationZoneVisualizationMode(_selectedVertex.VertexDetails.Vertex.Id));
         }
 
         public void ShowSelectedRobotVerticesColors()

--- a/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
@@ -260,7 +260,7 @@ namespace Maes.Statistics.Trackers
             }
 
             _visualizer.meshRenderer.enabled = true;
-            SetVisualizationMode(new SelectedRobotCommunicationRangeVisualizationMode(_selectedRobot, _collisionMap));
+            SetVisualizationMode(new SelectedRobotCommunicationRangeVisualizationMode(_selectedRobot));
         }
 
         public void ShowCommunicationZone()

--- a/Assets/Scripts/UI/Visualizers/Patrolling/CommunicationZoneVertices.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/CommunicationZoneVertices.cs
@@ -32,30 +32,23 @@ namespace Maes.UI.Visualizers.Patrolling
 {
     public sealed class CommunicationZoneVertices
     {
-        public Dictionary<int, HashSet<int>> CommunicationZoneTiles { get; }
-        public HashSet<int> AllCommunicationZoneTiles { get; } = new();
+        public Dictionary<int, Bitmap> CommunicationZoneTiles { get; }
+        public Bitmap AllCommunicationZoneTiles { get; }
 
         public CommunicationZoneVertices(SimulationMap<Tile> simulationMap, PatrollingMap patrollingMap, CommunicationManager communicationManager)
         {
-            CommunicationZoneTiles = patrollingMap.Vertices.ToDictionary(v => v.Id, _ => new HashSet<int>());
-
-            var positions = patrollingMap.Vertices.Select(v => v.Position).ToList();
-            var communicationZones = communicationManager.CalculateZones(positions);
-            var cellIndexToTriangleIndexes = simulationMap.CellIndexToTriangleIndexes();
-            using var bitmap = MapUtilities.MapToBitMap(simulationMap);
-            foreach (var vertex in patrollingMap.Vertices)
+            CommunicationZoneTiles = new Dictionary<int, Bitmap>();
+            var vertecies = patrollingMap.Vertices;
+            var communicationZones = communicationManager.CalculateZones(vertecies.Select(v => v.Position).ToList());
+            foreach (var vertex in vertecies)
             {
-                var tiles = communicationZones[vertex.Position];
-                if (tiles == null)
-                {
-                    continue;
-                }
-                foreach (var tile in tiles)
-                {
-                    var index = tile.x + tile.y * bitmap.Width;
-                    CommunicationZoneTiles[vertex.Id].UnionWith(cellIndexToTriangleIndexes[index]);
-                }
-                AllCommunicationZoneTiles.UnionWith(CommunicationZoneTiles[vertex.Id]);
+                CommunicationZoneTiles[vertex.Id] = communicationZones[vertex.Position];
+            }
+
+            AllCommunicationZoneTiles = new Bitmap(0, 0, simulationMap.WidthInTiles, simulationMap.HeightInTiles);
+            foreach (var (id, zone) in communicationZones)
+            {
+                AllCommunicationZoneTiles.Union(zone);
             }
         }
     }

--- a/Assets/Scripts/UI/Visualizers/Patrolling/CommunicationZoneVertices.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/CommunicationZoneVertices.cs
@@ -19,6 +19,9 @@
 // Casper Nyvang Sørensen,
 // Christian Ziegler Sejersen,
 // Jakob Meyer Olsen
+// Henrik van Peet
+// Mads Beyer Mogensen
+// Puvikaran Santhirasegaram
 
 using System.Collections.Generic;
 using System.Linq;

--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/CommunicationZoneVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/CommunicationZoneVisualizationMode.cs
@@ -19,32 +19,24 @@
 // Casper Nyvang Sørensen,
 // Christian Ziegler Sejersen,
 // Jakob Meyer Olsen
+// Henrik van Peet
+// Mads Beyer Mogensen
+// Puvikaran Santhirasegaram
 
-using UnityEngine;
 
 namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
 {
     public class CommunicationZoneVisualizationMode : IPatrollingVisualizationMode
     {
-        private PatrollingVisualizer Visualizer { get; }
-        private int SelectedVertexId { get; }
 
         public CommunicationZoneVisualizationMode(PatrollingVisualizer visualizer, int selectedVertexId)
         {
-            Visualizer = visualizer;
-            SelectedVertexId = selectedVertexId;
-            visualizer.SetAllColors(CellIndexToColor);
+            var communicationZone = visualizer.CommunicationZoneVertices.CommunicationZoneTiles[selectedVertexId];
+            visualizer.SetAllColors(communicationZone, PatrollingVisualizer.CommunicationColor, Visualizer.StandardCellColor);
         }
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
         {
             // Nothing to update since the visualization does not change
-        }
-
-        private Color32 CellIndexToColor(int cellIndex)
-        {
-            return Visualizer.CommunicationZoneVertices.CommunicationZoneTiles[SelectedVertexId].Contains(cellIndex)
-               ? PatrollingVisualizer.CommunicationColor
-               : Visualizers.Visualizer.StandardCellColor;
         }
     }
 }

--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/CommunicationZoneVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/CommunicationZoneVisualizationMode.cs
@@ -28,15 +28,23 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
 {
     public class CommunicationZoneVisualizationMode : IPatrollingVisualizationMode
     {
+        private readonly int _selectedVertexId;
+        private bool _isFirstUpdate = true;
 
-        public CommunicationZoneVisualizationMode(PatrollingVisualizer visualizer, int selectedVertexId)
+        public CommunicationZoneVisualizationMode(int selectedVertexId)
         {
-            var communicationZone = visualizer.CommunicationZoneVertices.CommunicationZoneTiles[selectedVertexId];
-            visualizer.SetAllColors(communicationZone, PatrollingVisualizer.CommunicationColor, Visualizer.StandardCellColor);
+            _selectedVertexId = selectedVertexId;
         }
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
         {
             // Nothing to update since the visualization does not change
+            if (_isFirstUpdate)
+            {
+                var communicationZone = visualizer.CommunicationZoneVertices.CommunicationZoneTiles[_selectedVertexId];
+                visualizer.SetAllColors(communicationZone, PatrollingVisualizer.CommunicationColor, Visualizer.StandardCellColor);
+
+                _isFirstUpdate = false;
+            }
         }
     }
 }

--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
@@ -14,12 +14,14 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         private readonly MonaRobot _robot;
         private readonly SimulationMap<Tile> _simulationMap;
         private HashSet<int> _triangleIndexes;
+        private Vector2Int _lastPosition;
 
         public SelectedRobotCommunicationRangeVisualizationMode(MonaRobot robot, SimulationMap<Tile> simulationMap)
         {
             _robot = robot;
             _simulationMap = simulationMap;
             _triangleIndexes = new HashSet<int>();
+            _lastPosition = new Vector2Int(int.MaxValue, int.MaxValue);
         }
 
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
@@ -31,8 +33,15 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         // Note: This is a debug feature, so performance is not critical.
         private void UpdateMapColor(PatrollingVisualizer visualizer)
         {
-            _triangleIndexes = new HashSet<int>();
             var position = _robot.Controller.SlamMap.CoarseMap.GetCurrentPosition();
+            // Communication is based on the tile the robot is on,
+            // so if the robot hasn't moved to a new tile we don't need to update the map.
+            if (position == _lastPosition)
+            {
+                return;
+            }
+
+            _triangleIndexes = new HashSet<int>();
             var communicationRangeBitmap = _robot.Controller.CommunicationManager.CalculateCommunicationZone(position);
             var cellIndexTriangleIndexes = _simulationMap.CellIndexToTriangleIndexes();
             foreach (var tile in communicationRangeBitmap)
@@ -41,6 +50,7 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
                 _triangleIndexes.UnionWith(cellIndexTriangleIndexes[index]);
             }
             visualizer.SetAllColors(CellIndexToColor);
+            _lastPosition = position;
         }
 
         private Color32 CellIndexToColor(int cellIndex)

--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
@@ -1,23 +1,17 @@
-using System.Collections.Generic;
-
-using Maes.Map;
-using Maes.Map.Generators;
 using Maes.Robot;
+
+using UnityEngine;
 
 namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
 {
     public class SelectedRobotCommunicationRangeVisualizationMode : IPatrollingVisualizationMode
     {
         private readonly MonaRobot _robot;
-        private readonly SimulationMap<Tile> _simulationMap;
-        private HashSet<int> _triangleIndexes;
         private Vector2Int _lastPosition;
 
-        public SelectedRobotCommunicationRangeVisualizationMode(MonaRobot robot, SimulationMap<Tile> simulationMap)
+        public SelectedRobotCommunicationRangeVisualizationMode(MonaRobot robot)
         {
             _robot = robot;
-            _simulationMap = simulationMap;
-            _triangleIndexes = new HashSet<int>();
             _lastPosition = new Vector2Int(int.MaxValue, int.MaxValue);
         }
 
@@ -38,7 +32,6 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
                 return;
             }
 
-            _triangleIndexes = new HashSet<int>();
             var communicationRangeBitmap = _robot.Controller.CommunicationManager.CalculateCommunicationZone(position);
             visualizer.SetAllColors(communicationRangeBitmap, PatrollingVisualizer.CommunicationColor, Visualizer.StandardCellColor);
             communicationRangeBitmap.Dispose();

--- a/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
+++ b/Assets/Scripts/UI/Visualizers/Patrolling/VisualizationModes/SelectedRobotCommunicationRangeVisualizationMode.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using Maes.Map;
 using Maes.Map.Generators;
 using Maes.Robot;
-using Maes.Utilities;
-
-using UnityEngine;
 
 namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
 {
@@ -14,14 +11,12 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         private readonly MonaRobot _robot;
         private readonly SimulationMap<Tile> _simulationMap;
         private HashSet<int> _triangleIndexes;
-        private Vector2Int _lastPosition;
 
         public SelectedRobotCommunicationRangeVisualizationMode(MonaRobot robot, SimulationMap<Tile> simulationMap)
         {
             _robot = robot;
             _simulationMap = simulationMap;
             _triangleIndexes = new HashSet<int>();
-            _lastPosition = new Vector2Int(int.MaxValue, int.MaxValue);
         }
 
         public void UpdateVisualization(PatrollingVisualizer visualizer, int currentTick)
@@ -33,31 +28,11 @@ namespace Maes.UI.Visualizers.Patrolling.VisualizationModes
         // Note: This is a debug feature, so performance is not critical.
         private void UpdateMapColor(PatrollingVisualizer visualizer)
         {
-            var position = _robot.Controller.SlamMap.CoarseMap.GetCurrentPosition();
-            // Communication is based on the tile the robot is on,
-            // so if the robot hasn't moved to a new tile we don't need to update the map.
-            if (position == _lastPosition)
-            {
-                return;
-            }
-
             _triangleIndexes = new HashSet<int>();
+            var position = _robot.Controller.SlamMap.CoarseMap.GetCurrentPosition();
             var communicationRangeBitmap = _robot.Controller.CommunicationManager.CalculateCommunicationZone(position);
-            var cellIndexTriangleIndexes = _simulationMap.CellIndexToTriangleIndexes();
-            foreach (var tile in communicationRangeBitmap)
-            {
-                var index = tile.x + tile.y * communicationRangeBitmap.Width;
-                _triangleIndexes.UnionWith(cellIndexTriangleIndexes[index]);
-            }
-            visualizer.SetAllColors(CellIndexToColor);
-            _lastPosition = position;
-        }
-
-        private Color32 CellIndexToColor(int cellIndex)
-        {
-            return _triangleIndexes.Contains(cellIndex)
-               ? PatrollingVisualizer.CommunicationColor
-               : Visualizer.StandardCellColor;
+            visualizer.SetAllColors(communicationRangeBitmap, PatrollingVisualizer.CommunicationColor, Visualizer.StandardCellColor);
+            communicationRangeBitmap.Dispose();
         }
     }
 }

--- a/Assets/Scripts/UI/Visualizers/Visualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Visualizer.cs
@@ -173,8 +173,6 @@ namespace Maes.UI.Visualizers
             }
 
             SetAllColors(CellIndexToColor);
-
-            _mesh.colors32 = _colors;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/Visualizers/Visualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Visualizer.cs
@@ -162,7 +162,6 @@ namespace Maes.UI.Visualizers
             foreach (var tile in map)
             {
                 var index = tile.x + tile.y * map.Width;
-                //var color = map.Contains(width, height) ? isContained : isNotContained;
                 triangleIndexes.UnionWith(_cellIndexToTriangleIndexes[index]);
             }
 

--- a/Assets/Scripts/UI/Visualizers/Visualizer.cs
+++ b/Assets/Scripts/UI/Visualizers/Visualizer.cs
@@ -165,9 +165,9 @@ namespace Maes.UI.Visualizers
                 triangleIndexes.UnionWith(_cellIndexToTriangleIndexes[index]);
             }
 
-            Color32 CellIndexToColor(int cellIndex)
+            Color32 CellIndexToColor(int triangleIndex)
             {
-                return triangleIndexes.Contains(cellIndex)
+                return triangleIndexes.Contains(triangleIndex)
                 ? isContained
                 : isNotContained;
             }

--- a/Assets/Tests/EditModeTests/CommunicationZoneVerticesTests.cs
+++ b/Assets/Tests/EditModeTests/CommunicationZoneVerticesTests.cs
@@ -29,6 +29,7 @@ using Maes.Map.Generators;
 using Maes.Robot;
 using Maes.UI;
 using Maes.UI.Visualizers.Patrolling;
+using Maes.Utilities;
 
 using NUnit.Framework;
 
@@ -185,11 +186,10 @@ namespace Tests.EditModeTests
                 communicationZoneVertices.CommunicationZoneTiles[0].Count + communicationZoneVertices.CommunicationZoneTiles[1].Count);
 
             // Calculate intersection size
-            var intersection = new HashSet<int>(communicationZoneVertices.CommunicationZoneTiles[0]);
-            intersection.IntersectWith(communicationZoneVertices.CommunicationZoneTiles[1]);
+            var intersection = communicationZoneVertices.CommunicationZoneTiles[0].Intersect(communicationZoneVertices.CommunicationZoneTiles[1]);
 
             // Verify intersection is not empty
-            Assert.Greater(intersection.Count, 0);
+            Assert.Greater(intersection.Count(), 0);
         }
 
         [Test]
@@ -239,11 +239,10 @@ namespace Tests.EditModeTests
 
             // Assert
             // Calculate intersection size
-            var intersection = new HashSet<int>(communicationZoneVertices.CommunicationZoneTiles[0]);
-            intersection.IntersectWith(communicationZoneVertices.CommunicationZoneTiles[1]);
+            var intersection = communicationZoneVertices.CommunicationZoneTiles[0].Intersect(communicationZoneVertices.CommunicationZoneTiles[1]);
 
             // Verify communication zones don't intersect because of the wall
-            Assert.AreEqual(0, intersection.Count);
+            Assert.AreEqual(0, intersection.Count());
         }
 
         [Test]
@@ -321,15 +320,15 @@ namespace Tests.EditModeTests
             Assert.AreEqual(4, communicationZoneVertices.CommunicationZoneTiles.Count);
 
             // Create manual union to compare with AllCommunicationZoneTiles
-            var manualUnion = new HashSet<int>();
+            var manualUnion = new Bitmap(0, 0, simulationMap.WidthInTiles, simulationMap.HeightInTiles);
             for (var i = 0; i < 4; i++)
             {
-                manualUnion.UnionWith(communicationZoneVertices.CommunicationZoneTiles[i]);
+                manualUnion.Union(communicationZoneVertices.CommunicationZoneTiles[i]);
             }
 
             // Compare manual union with AllCommunicationZoneTiles
             Assert.AreEqual(manualUnion.Count, communicationZoneVertices.AllCommunicationZoneTiles.Count);
-            Assert.IsTrue(manualUnion.SetEquals(communicationZoneVertices.AllCommunicationZoneTiles));
+            Assert.IsTrue(manualUnion.Equals(communicationZoneVertices.AllCommunicationZoneTiles));
         }
     }
 }

--- a/Assets/Tests/EditModeTests/CommunicationZoneVerticesTests.cs
+++ b/Assets/Tests/EditModeTests/CommunicationZoneVerticesTests.cs
@@ -242,7 +242,7 @@ namespace Tests.EditModeTests
             var intersection = communicationZoneVertices.CommunicationZoneTiles[0].Intersect(communicationZoneVertices.CommunicationZoneTiles[1]);
 
             // Verify communication zones don't intersect because of the wall
-            Assert.AreEqual(0, intersection.Count());
+            Assert.IsFalse(intersection.Any());
         }
 
         [Test]
@@ -328,7 +328,7 @@ namespace Tests.EditModeTests
 
             // Compare manual union with AllCommunicationZoneTiles
             Assert.AreEqual(manualUnion.Count, communicationZoneVertices.AllCommunicationZoneTiles.Count);
-            Assert.IsTrue(manualUnion.Equals(communicationZoneVertices.AllCommunicationZoneTiles));
+            Assert.AreEqual(manualUnion, communicationZoneVertices.AllCommunicationZoneTiles);
         }
     }
 }


### PR DESCRIPTION
The visualization mode was broken.
The ctor would set the map colors, but the map is reset in SetVisualizationMode()
I fixed this.
Also now it uses bitmaps for stuff instead of weird datatypes.
The bitmap => triangleIndecies convertion has been moved to the visualizer, since multiple visualization mode make this mapping. 