### PR TITLE
Refactor rnn waypoint connector

### DIFF
--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitioningGenerator.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitioningGenerator.cs
@@ -19,6 +19,9 @@
 // Casper Nyvang Sørensen,
 // Christian Ziegler Sejersen,
 // Jakob Meyer Olsen
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
 
 using System;
 using System.Collections.Generic;

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
@@ -76,7 +76,7 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
 
             ConnectIslands(vertices, distanceMatrix);
 
-            Debug.LogFormat("Connect Vertices took {0} s", Time.realtimeSinceStartup - startTime);
+            Debug.LogFormat($"{nameof(ReverseNearestNeighborWaypointConnector)} ConnectVertices took {0} s", Time.realtimeSinceStartup - startTime);
 
             return vertices;
         }

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
@@ -52,6 +52,18 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
             var distanceMatrix = MapUtilities.CalculateDistanceMatrix(map, vertexPositions);
 
             var reverseNearestNeighbors = MapUtilities.GetReverseNearestNeighbors(distanceMatrix, numberOfReverseNearestNeighbors);
+
+            var vertices = ConnectReverseNearestNeighbors(vertexPositions, colorIslands, defaultColor, nextId, reverseNearestNeighbors);
+
+            ConnectIslands(vertices, distanceMatrix);
+
+            Debug.LogFormat($"{nameof(ReverseNearestNeighborWaypointConnector)} ConnectVertices took {0} s", Time.realtimeSinceStartup - startTime);
+
+            return vertices;
+        }
+
+        private static Vertex[] ConnectReverseNearestNeighbors(IReadOnlyCollection<Vector2Int> vertexPositions, bool colorIslands, Color defaultColor, int nextId, Dictionary<Vector2Int, List<Vector2Int>> reverseNearestNeighbors)
+        {
             var vertices = vertexPositions.Select(position => new Vertex(nextId++, position)).ToArray();
             var vertexMap = vertices.ToDictionary(v => v.Position);
 
@@ -74,13 +86,8 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
                 }
             }
 
-            ConnectIslands(vertices, distanceMatrix);
-
-            Debug.LogFormat($"{nameof(ReverseNearestNeighborWaypointConnector)} ConnectVertices took {0} s", Time.realtimeSinceStartup - startTime);
-
             return vertices;
         }
-
 
         private static void ConnectIslands(
                  Vertex[] vertices,

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
@@ -45,7 +45,7 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
         /// <param name="nextId">Used by partitioning.</param>
         /// <param name="numberOfReverseNearestNeighbors">The amount of RNN's to connect(make an edge) to the current vertex.</param>
         /// <returns>Vertices with connections(edges) to other vertices.</returns>
-        public static Vertex[] ConnectVertices(Bitmap map, IReadOnlyCollection<Vector2Int> vertexPositions, bool colorIslands, Color defaultColor, int nextId = 0, int numberOfReverseNearestNeighbors = 1)
+        public static Vertex[] ConnectVertices(Bitmap map, IReadOnlyCollection<Vector2Int> vertexPositions, int nextId = 0, int numberOfReverseNearestNeighbors = 1)
         {
             var startTime = Time.realtimeSinceStartup;
 
@@ -53,7 +53,7 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
 
             var reverseNearestNeighbors = MapUtilities.GetReverseNearestNeighbors(distanceMatrix, numberOfReverseNearestNeighbors);
 
-            var vertices = ConnectReverseNearestNeighbors(vertexPositions, colorIslands, defaultColor, nextId, reverseNearestNeighbors);
+            var vertices = ConnectReverseNearestNeighbors(vertexPositions, nextId, reverseNearestNeighbors);
 
             ConnectIslands(vertices, distanceMatrix);
 
@@ -62,7 +62,7 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
             return vertices;
         }
 
-        private static Vertex[] ConnectReverseNearestNeighbors(IReadOnlyCollection<Vector2Int> vertexPositions, bool colorIslands, Color defaultColor, int nextId, Dictionary<Vector2Int, List<Vector2Int>> reverseNearestNeighbors)
+        private static Vertex[] ConnectReverseNearestNeighbors(IReadOnlyCollection<Vector2Int> vertexPositions, int nextId, Dictionary<Vector2Int, List<Vector2Int>> reverseNearestNeighbors)
         {
             var vertices = vertexPositions.Select(position => new Vertex(nextId++, position)).ToArray();
             var vertexMap = vertices.ToDictionary(v => v.Position);
@@ -73,13 +73,10 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
                 {
                     continue;
                 }
-                var color = colorIslands ? Random.ColorHSV(0f, 1f, 0.5f, 1f, 0.5f, 1f) : defaultColor;
-                vertex.Color = color;
                 foreach (var neighborPos in neighbors)
                 {
                     if (vertexMap.TryGetValue(neighborPos, out var neighborVertex))
                     {
-                        neighborVertex.Color = color;
                         vertex.AddNeighbor(neighborVertex);
                         neighborVertex.AddNeighbor(vertex);
                     }

--- a/Assets/Scripts/Simulation/Patrolling/PatrollingSimulationScenario.cs
+++ b/Assets/Scripts/Simulation/Patrolling/PatrollingSimulationScenario.cs
@@ -6,8 +6,6 @@ using Maes.Map.Generators.Patrolling.Waypoints.Connectors;
 using Maes.Map.Generators.Patrolling.Waypoints.Generators;
 using Maes.Robot;
 
-using UnityEngine;
-
 namespace Maes.Simulation.Patrolling
 {
     public delegate PatrollingMap PatrollingMapFactory(SimulationMap<Tile> map);
@@ -40,7 +38,7 @@ namespace Maes.Simulation.Patrolling
             TotalCycles = totalCycles;
             StopAfterDiff = stopAfterDiff;
             Partitions = partitions;
-            PatrollingMapFactory = patrollingMapFactory ?? ((map) => GreedyMostVisibilityWaypointGenerator.MakePatrollingMap(map, (bitmap, positions) => ReverseNearestNeighborWaypointConnector.ConnectVertices(bitmap, positions, true, Color.green)));
+            PatrollingMapFactory = patrollingMapFactory ?? ((map) => GreedyMostVisibilityWaypointGenerator.MakePatrollingMap(map, (bitmap, positions) => ReverseNearestNeighborWaypointConnector.ConnectVertices(bitmap, positions)));
         }
     }
 }


### PR DESCRIPTION
Remove the color islands debug functionality.
The color islands functionality was used to color partitions, which is convoluted.
It's much more simple now, also fewer parameters have to be supplied to the methods.