### PR TITLE
Finding sharing vertices between the neighbor partition instead of all partitions

### DIFF
--- a/Assets/Scripts/Experiments/Patrolling/HMPPatrollingExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPatrollingExperiment.cs
@@ -39,7 +39,7 @@ namespace Maes.Experiments.Patrolling
     {
         private void Start()
         {
-            const int robotCount = 3;
+            const int robotCount = 4;
             const int seed = 123;
             const int mapSize = 100;
             const string algoName = "HMPPatrollingAlgorithm";

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/AllConnectedWaypointConnector.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/AllConnectedWaypointConnector.cs
@@ -38,6 +38,13 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
                 id++;
             }
 
+            ConnectVertices(vertices);
+
+            return vertices;
+        }
+
+        public static void ConnectVertices(IReadOnlyCollection<Vertex> vertices)
+        {
             foreach (var vertex in vertices)
             {
                 foreach (var neighborVertex in vertices)
@@ -50,8 +57,6 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
                     vertex.AddNeighbor(neighborVertex);
                 }
             }
-
-            return vertices;
         }
     }
 }

--- a/Assets/Scripts/Map/PatrollingMap.cs
+++ b/Assets/Scripts/Map/PatrollingMap.cs
@@ -24,6 +24,11 @@ namespace Maes.Map
         {
         }
 
+        public PatrollingMap(IReadOnlyList<Vertex> vertices, CoarseGrainedMap simulationMap)
+            : this(vertices, CreatePaths(vertices, simulationMap))
+        {
+        }
+
         public PatrollingMap(IReadOnlyList<Vertex> vertices, SimulationMap<Tile> simulationMap, Dictionary<int, Vertex[]> partitions)
             : this(vertices, CreatePaths(vertices, simulationMap), partitions)
         {
@@ -74,6 +79,17 @@ namespace Maes.Map
             // HACK: Creating a slam map with robot constraints seems a bit hacky tbh :(
             var slamMap = new SlamMap(simulationMap, new RobotConstraints(mapKnown: true), 0);
             var coarseMap = slamMap.CoarseMap;
+
+            return CreatePaths(vertices, coarseMap);
+        }
+
+        private static IReadOnlyDictionary<(int, int), IReadOnlyList<PathStep>> CreatePaths(IReadOnlyList<Vertex> vertices, CoarseGrainedMap coarseMap)
+        {
+            // TODO: Skip this if we can use the breath first search stuff from WatchmanRouteSolver.
+            // TODO: Of cause this requires specific code for that waypoint generation algorithm.
+
+            var startTime = Time.realtimeSinceStartup;
+
             var aStar = new MyAStar();
             var paths = new Dictionary<(int, int), IReadOnlyList<PathStep>>();
             foreach (var vertex in vertices)

--- a/Assets/Scripts/Utilities/PartitionsExtensions.cs
+++ b/Assets/Scripts/Utilities/PartitionsExtensions.cs
@@ -22,7 +22,7 @@ namespace Maes.Utilities
             }
         }
 
-        public static List<PossibleMeetingPoint> GetNeighborsPartitionsWithNoCommonVertices(this Dictionary<int, PartitionInfo> partitionInfoByRobotId, PatrollingMap patrollingMap)
+        public static List<PossibleMeetingPoint> GetNeighborsPartitionsWithNoCommonVertices(this Dictionary<int, PartitionInfo> partitionInfoByRobotId, IReadOnlyCollection<Vertex> vertices)
         {
             var possibleMeetingPoints = new List<PossibleMeetingPoint>();
 
@@ -34,7 +34,7 @@ namespace Maes.Utilities
                     continue;
                 }
 
-                var possibleMeetingPoint = GetPossibleMeetingPointsForPartitions(partitionInfo1, partitionInfo2, patrollingMap);
+                var possibleMeetingPoint = GetPossibleMeetingPointsForPartitions(partitionInfo1, partitionInfo2, vertices);
                 if (possibleMeetingPoint.Connections.Count > 0)
                 {
                     possibleMeetingPoints.Add(possibleMeetingPoint);
@@ -44,10 +44,10 @@ namespace Maes.Utilities
             return possibleMeetingPoints;
         }
 
-        private static PossibleMeetingPoint GetPossibleMeetingPointsForPartitions(PartitionInfo partitionInfo1, PartitionInfo partitionInfo2, PatrollingMap patrollingMap)
+        private static PossibleMeetingPoint GetPossibleMeetingPointsForPartitions(PartitionInfo partitionInfo1, PartitionInfo partitionInfo2, IReadOnlyCollection<Vertex> vertices)
         {
             var possibleMeetingPoint = new PossibleMeetingPoint(partitionInfo1.RobotId, partitionInfo2.RobotId);
-            var partition1Vertices = patrollingMap.Vertices.Where(vertex => partitionInfo1.VertexIds.Contains(vertex.Id));
+            var partition1Vertices = vertices.Where(vertex => partitionInfo1.VertexIds.Contains(vertex.Id));
             foreach (var vertex in partition1Vertices)
             {
                 foreach (var neighborVertex in vertex.Neighbors)

--- a/Assets/Tests/EditModeTests/MeetingPointsWithTimeTest.cs
+++ b/Assets/Tests/EditModeTests/MeetingPointsWithTimeTest.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 
 using Maes.Map;
 using Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints;
+using Maes.Map.Generators.Patrolling.Waypoints.Connectors;
 using Maes.Robot;
 
 using NUnit.Framework;
@@ -46,7 +47,7 @@ namespace Tests.EditModeTests
         [Test]
         public void PartitionGeneratorHMPPartitionInfo_OneMeetingPointCorrectTime_Test()
         {
-            var (simulationMap, patrollingMap, vertexPositionsByPartitionId) = new PartitionSimulationMapBuilder(TestMap1).Build();
+            var (simulationMap, patrollingMap, vertexPositionsByPartitionId) = new PartitionSimulationMapBuilder(TestMap1, AllConnectedWaypointConnector.ConnectVertices).Build();
             var vertices = patrollingMap.Vertices;
 
             var robotConstraints = new RobotConstraints(mapKnown: true);
@@ -79,7 +80,7 @@ namespace Tests.EditModeTests
         [Test]
         public void PartitionGeneratorHMPPartitionInfo_TwoMeetingPointCorrectTime_Test()
         {
-            var (simulationMap, patrollingMap, vertexPositionsByPartitionId) = new PartitionSimulationMapBuilder(TestMap2).Build();
+            var (simulationMap, patrollingMap, vertexPositionsByPartitionId) = new PartitionSimulationMapBuilder(TestMap2, AllConnectedWaypointConnector.ConnectVertices).Build();
             var vertices = patrollingMap.Vertices;
 
             var robotConstraints = new RobotConstraints(mapKnown: true);

--- a/Assets/Tests/EditModeTests/PartitionGeneratorWithMeetingPointTest.cs
+++ b/Assets/Tests/EditModeTests/PartitionGeneratorWithMeetingPointTest.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Maes.Map;
+using Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints;
+using Maes.Map.Generators.Patrolling.Waypoints.Connectors;
+using Maes.Robot;
+
+using NUnit.Framework;
+
+using Tests.EditModeTests.Utilities.MapInterpreter.MapBuilder;
+using Tests.EditModeTests.Utilities.Partitions;
+
+namespace Tests.EditModeTests
+{
+    public class PartitionGeneratorWithMeetingPointTest
+    {
+        private const string TestMap1 = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;" +
+                                        "X                                X;" +
+                                        "X   1     1            2     2   X;" +
+                                        "X                                X;" +
+                                        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+        [Test]
+        public void PartitionGenerator_GenerateOneSharingVertex_Test()
+        {
+            var (simulationMap, patrollingMap, verticesByPartitionId) = new PartitionSimulationMapBuilder(TestMap1, AllConnectedWaypointConnector.ConnectVertices).Build();
+
+            var robotConstraints = new RobotConstraints(mapKnown: true);
+            var coarseMap = new SlamMap(simulationMap, robotConstraints, 0).CoarseMap;
+            var generator = new PartitionGeneratorWithMeetingPoint(new TestPartitionGenerator(verticesByPartitionId));
+            var estimationTravel = new TravelEstimator(coarseMap, robotConstraints);
+
+            generator.SetMaps(patrollingMap, coarseMap, (s, e) => estimationTravel.EstimateTime(s, e));
+
+            var partitions = generator.GeneratePartitions(new HashSet<int> { 1, 2 });
+
+            //Check that the partitions share vertex id 1
+            Assert.AreEqual(1, partitions[1].VertexIds.Intersect(partitions[2].VertexIds).ToArray()[0]);
+        }
+
+        private const string TestMap2 = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;" +
+                                        "X                                X;" +
+                                        "X   1     12           2     2   X;" +
+                                        "X   3                        3   X;" +
+                                        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+        [Test]
+        public void PartitionGenerator_GenerateTwoSharingVertex_Test()
+        {
+            var (simulationMap, patrollingMap, verticesByPartitionId) = new PartitionSimulationMapBuilder(TestMap2, AllConnectedWaypointConnector.ConnectVertices).Build();
+
+            var robotConstraints = new RobotConstraints(mapKnown: true);
+            var coarseMap = new SlamMap(simulationMap, robotConstraints, 0).CoarseMap;
+            var generator = new PartitionGeneratorWithMeetingPoint(new TestPartitionGenerator(verticesByPartitionId));
+            var estimationTravel = new TravelEstimator(coarseMap, robotConstraints);
+
+            generator.SetMaps(patrollingMap, coarseMap, (s, e) => estimationTravel.EstimateTime(s, e));
+
+            var partitions = generator.GeneratePartitions(new HashSet<int> { 1, 2, 3 });
+
+            //Check that the partitions 1 and 3 share vertex id 0
+            Assert.AreEqual(0, partitions[1].VertexIds.Intersect(partitions[3].VertexIds).ToArray()[0]);
+
+            //Check that the partitions 2 and 3 share vertex id 3
+            Assert.AreEqual(3, partitions[2].VertexIds.Intersect(partitions[3].VertexIds).ToArray()[0]);
+        }
+
+        private const string TestMap3 = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;" +
+                                        "X   1     12           2    2    X;" +
+                                        "X   3    xxxxxxxxxxxxxxxx    4   X;" +
+                                        "X    3          x            4   X;" +
+                                        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+
+        [Test]
+        public void PartitionGenerator_GenerateSharingVertexNotAllPartitionsAreNeighbor_Test()
+        {
+            var (simulationMap, patrollingMap, verticesByPartitionId) = new PartitionSimulationMapBuilder(TestMap3, AllConnectedWaypointConnector.ConnectVertices).Build();
+
+            var robotConstraints = new RobotConstraints(mapKnown: true);
+            var coarseMap = new SlamMap(simulationMap, robotConstraints, 0).CoarseMap;
+            var generator = new PartitionGeneratorWithMeetingPoint(new TestPartitionGenerator(verticesByPartitionId));
+            var estimationTravel = new TravelEstimator(coarseMap, robotConstraints);
+
+            generator.SetMaps(patrollingMap, coarseMap, (s, e) => estimationTravel.EstimateTime(s, e));
+
+            var partitions = generator.GeneratePartitions(new HashSet<int> { 1, 2, 3, 4 });
+
+            //Check that the partitions 1 and 2 share vertex id 1
+            Assert.AreEqual(1, partitions[1].VertexIds.Intersect(partitions[2].VertexIds).ToArray()[0]);
+
+            //Check that the partitions 1 and 3 share vertex id 0
+            Assert.AreEqual(0, partitions[1].VertexIds.Intersect(partitions[3].VertexIds).ToArray()[0]);
+
+            //Check that the partitions 1 and 4 have no shared vertex
+            Assert.IsFalse(partitions[1].VertexIds.ToHashSet().Overlaps(partitions[4].VertexIds));
+
+            //Check that the partitions 2 and 3 have no shared vertex
+            Assert.IsFalse(partitions[2].VertexIds.ToHashSet().Overlaps(partitions[3].VertexIds));
+
+            //Check that the partitions 2 and 4 share vertex id 3
+            Assert.AreEqual(3, partitions[2].VertexIds.Intersect(partitions[4].VertexIds).ToArray()[0]);
+
+            //Check that the partitions 3 and 4 have no shared vertex
+            Assert.IsFalse(partitions[3].VertexIds.ToHashSet().Overlaps(partitions[4].VertexIds));
+        }
+    }
+}

--- a/Assets/Tests/EditModeTests/PartitionGeneratorWithMeetingPointTest.cs.meta
+++ b/Assets/Tests/EditModeTests/PartitionGeneratorWithMeetingPointTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03facad593724ffaacc539d0b5c4a600


### PR DESCRIPTION
Previously the meeting points were not correctly found. If two partitions are not sharing a common vertex, but they are neighbor meaning an edge between one of vertices in partition A and one of vertices in partition B, then a one of the vertices should be meeting point. However since all vertices are connected with all vertices, all partitions are neighbor to each other. That is not good, and are now fixed in this PR.