### PR TITLE
Fix release build error

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/PartitionComponent.cs
@@ -34,7 +34,8 @@ namespace Maes.Algorithms.Patrolling.Components
 
             while (true)
             {
-                Debug.Assert(_virtualStigmergyComponent.TryGet(_robotId, out var partitionInfo));
+                var success = _virtualStigmergyComponent.TryGet(_robotId, out var partitionInfo);
+                Debug.Assert(success);
                 PartitionInfo = partitionInfo;
                 yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
             }


### PR DESCRIPTION
It seems like unity deletes Debug code when building in release mode. This fucked up as the TryGet function call was inside the Debug.Assert call. This is a unity bug. Work around it! Time to file a bug to unity? :)