### PR TITLE
Virtual Stigmergy: Add marker type to differentiate stigmergies with same key,value types

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/PartitionComponent.cs
@@ -10,7 +10,7 @@ namespace Maes.Algorithms.Patrolling.Components
 {
     public class PartitionComponent : IComponent
     {
-        public PartitionComponent(IRobotController controller, StartupComponent<Dictionary<int, HMPPartitionInfo>> startupComponent, VirtualStigmergyComponent<int, HMPPartitionInfo> virtualStigmergyComponent)
+        public PartitionComponent(IRobotController controller, StartupComponent<Dictionary<int, HMPPartitionInfo>> startupComponent, VirtualStigmergyComponent<int, HMPPartitionInfo, PartitionComponent> virtualStigmergyComponent)
         {
             _robotId = controller.Id;
             _startupComponent = startupComponent;
@@ -21,7 +21,7 @@ namespace Maes.Algorithms.Patrolling.Components
 
         private readonly int _robotId;
         private readonly StartupComponent<Dictionary<int, HMPPartitionInfo>> _startupComponent;
-        private readonly VirtualStigmergyComponent<int, HMPPartitionInfo> _virtualStigmergyComponent;
+        private readonly VirtualStigmergyComponent<int, HMPPartitionInfo, PartitionComponent> _virtualStigmergyComponent;
 
         public PartitionInfo? PartitionInfo { get; private set; }
 

--- a/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
@@ -41,7 +41,8 @@ namespace Maes.Algorithms.Patrolling.Components
     /// Implements the paper: A Tuple Space for Data Sharing in Robot Swarms
     /// DOI 10.4108/eai.3-12-2015.2262503
     /// </remarks>
-    public sealed class VirtualStigmergyComponent<TKey, TValue> : IComponent
+    // ReSharper disable once UnusedTypeParameter
+    public sealed class VirtualStigmergyComponent<TKey, TValue, TMarker> : IComponent
         where TKey : notnull
     {
         public delegate ValueInfo OnConflictDelegate(TKey key, ValueInfo localValueInfo, ValueInfo incomingValueInfo);
@@ -58,17 +59,12 @@ namespace Maes.Algorithms.Patrolling.Components
         public int PostUpdateOrder { get; } = -1000;
 
         /// <summary>
-        /// Gets a queue of messages that are not from virtual stigmergy.
-        /// </summary>
-        public Queue<object> NonVirtualStigmergyMessageQueue { get; } = new Queue<object>();
-
-        /// <summary>
         /// Gets how many key-value pairs are in the local knowledge.
         /// </summary>
         public int Size => _localKnowledge.Count;
 
         /// <summary>
-        /// Creates a new instance of <see cref="VirtualStigmergyComponent{TValue}"/>.
+        /// Creates a new instance of <see cref="VirtualStigmergyComponent{TKey,TValue,TMarker}"/>.
         /// </summary>
         /// <param name="onConflictDelegate">A function to call to resolve conflicts.</param>
         /// <param name="controller">The robot controller.</param>
@@ -98,11 +94,6 @@ namespace Maes.Algorithms.Patrolling.Components
                                 break;
                         }
                     }
-                    else
-                    {
-                        NonVirtualStigmergyMessageQueue.Enqueue(objectMessage);
-                    }
-
                 }
 
                 yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
@@ -224,7 +215,7 @@ namespace Maes.Algorithms.Patrolling.Components
         /// <param name="key">The key to get.</param>
         /// <param name="value">The value.</param>
         /// <returns><see langword="true"/> if the key is present.</returns>
-        /// <remarks>You probably don't want to use this method. See <see cref="Get"/>.</remarks>
+        /// <remarks>You probably don't want to use this method. See <see cref="TryGet"/>.</remarks>
         public bool TryGetNonSending(TKey key, [NotNullWhen(true)] out TValue? value)
         {
             var ret = _localKnowledge.TryGetValue(key, out var info);

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithm.cs
@@ -57,8 +57,8 @@ namespace Maes.Algorithms.Patrolling
         private readonly IPartitionGenerator<HMPPartitionInfo> _partitionGenerator;
         private readonly HeuristicConscientiousReactiveLogic _heuristicConscientiousReactiveLogic;
 
-        private readonly VirtualStigmergyComponent<int, HMPPartitionInfo>.OnConflictDelegate _onConflict = (_, _, incoming) => incoming;
-        private VirtualStigmergyComponent<int, HMPPartitionInfo> _virtualStigmergyComponent = null!;
+        private readonly VirtualStigmergyComponent<int, HMPPartitionInfo, PartitionComponent>.OnConflictDelegate _onConflict = (_, _, incoming) => incoming;
+        private VirtualStigmergyComponent<int, HMPPartitionInfo, PartitionComponent> _virtualStigmergyComponent = null!;
         private StartupComponent<Dictionary<int, HMPPartitionInfo>> _startupComponent = null!;
         private PartitionComponent _partitionComponent = null!;
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
@@ -69,7 +69,7 @@ namespace Maes.Algorithms.Patrolling
             _controller = controller;
             _partitionGenerator.SetMaps(patrollingMap, controller.SlamMap.CoarseMap, (s, e) => controller.TravelEstimator.EstimateTime(s, e));
             _startupComponent = new StartupComponent<Dictionary<int, HMPPartitionInfo>>(controller, _partitionGenerator.GeneratePartitions);
-            _virtualStigmergyComponent = new VirtualStigmergyComponent<int, HMPPartitionInfo>(_onConflict, controller);
+            _virtualStigmergyComponent = new VirtualStigmergyComponent<int, HMPPartitionInfo, PartitionComponent>(_onConflict, controller);
             _partitionComponent = new PartitionComponent(controller, _startupComponent, _virtualStigmergyComponent);
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap, GetInitialVertexToPatrol);
 

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/Components/VirtualStigmergyTests.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/Components/VirtualStigmergyTests.cs
@@ -246,7 +246,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
         {
             public override string AlgorithmName { get; } = "VirtualStigmergyTests";
 
-            public VirtualStigmergyComponent<string, string> VirtualStigmergyComponent { get; private set; }
+            public VirtualStigmergyComponent<string, string, TestingAlgorithm> VirtualStigmergyComponent { get; private set; }
 
             public IRobotController Controller { get; private set; }
 
@@ -254,16 +254,21 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
             {
                 Controller = controller;
                 VirtualStigmergyComponent =
-                    new VirtualStigmergyComponent<string, string>(OnConflict, controller);
+                    new VirtualStigmergyComponent<string, string, TestingAlgorithm>(OnConflict, controller);
 
                 return new IComponent[] { VirtualStigmergyComponent };
             }
 
-            private static VirtualStigmergyComponent<string, string>.ValueInfo OnConflict(string key,
-                VirtualStigmergyComponent<string, string>.ValueInfo localValueInfo,
-                VirtualStigmergyComponent<string, string>.ValueInfo incomingValueInfo)
+            private static VirtualStigmergyComponent<string, string, TestingAlgorithm>.ValueInfo OnConflict(string key,
+                VirtualStigmergyComponent<string, string, TestingAlgorithm>.ValueInfo localValueInfo,
+                VirtualStigmergyComponent<string, string, TestingAlgorithm>.ValueInfo incomingValueInfo)
             {
-                return localValueInfo;
+                if (localValueInfo.RobotId < incomingValueInfo.RobotId)
+                {
+                    return localValueInfo;
+                }
+
+                return incomingValueInfo;
             }
         }
     }


### PR DESCRIPTION
This allows the user to have multiple virtual stigmergies that share the same key and value types.
Without this messages sent from one VirtualStigmergy<int, int> would be sent to another.

To have multiple VirtualStigmergy's with the same type in one class, create private marker classes inside the class.
For example:

```cs
private sealed class VertexMarker {}
private sealed class RobotMarker {}

VirtualStigmergy<int, int, VertexMarker> _vertexStigmergy;
VirtualStigmergy<int, int, RobotMarker> _robotStigmergy;
```

vertexStigmergy and robotStigmergy will not recieve each others messages as they are distinct types.