### PR TITLE
Immutable value virtual stigmergy

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
@@ -20,6 +20,7 @@
 // Uncomment this to enable debug log tracing of messages.
 // #define VIRTUAL_STIGMERGY_TRACING
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -44,6 +45,7 @@ namespace Maes.Algorithms.Patrolling.Components
     // ReSharper disable once UnusedTypeParameter
     public sealed class VirtualStigmergyComponent<TKey, TValue, TMarker> : IComponent
         where TKey : notnull
+        where TValue : ICloneable
     {
         public delegate ValueInfo OnConflictDelegate(TKey key, ValueInfo localValueInfo, ValueInfo incomingValueInfo);
 
@@ -130,7 +132,7 @@ namespace Maes.Algorithms.Patrolling.Components
 
                 // We need to do conflict resolution
                 var newValueInfo = _onConflictDelegate(message.Key, valueInfo,
-                    new ValueInfo(message.Timestamp, message.RobotId, message.Value!));
+                    new ValueInfo(message.Timestamp, message.RobotId, (TValue)message.Value!.Clone())); // Clone the value from the message to ensure nothing is smuggled.
 
                 // Update our local knowledge and create a put message.
                 // I don't know if we should do this the paper is not clear on it.

--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/MeetingPoint.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/MeetingPoint.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Collections.Generic;
+
+using Accord.Math;
 
 namespace Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints
 {
-    public class MeetingPoint
+    public readonly struct MeetingPoint : IEquatable<MeetingPoint>
     {
         public MeetingPoint(int vertexId, int atTicks, IReadOnlyCollection<int> robotIds)
         {
@@ -12,7 +15,34 @@ namespace Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints
         }
 
         public int VertexId { get; }
+
         public int AtTicks { get; }
+
         public IReadOnlyCollection<int> RobotIds { get; }
+
+        public bool Equals(MeetingPoint other)
+        {
+            return VertexId == other.VertexId && AtTicks == other.AtTicks && RobotIds.SetEquals(other.RobotIds);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MeetingPoint other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(VertexId, AtTicks, RobotIds);
+        }
+
+        public static bool operator ==(MeetingPoint left, MeetingPoint right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MeetingPoint left, MeetingPoint right)
+        {
+            return !left.Equals(right);
+        }
     }
 }

--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/PartitionGeneratorWithMeetingPoint.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/PartitionGeneratorWithMeetingPoint.cs
@@ -77,8 +77,12 @@ namespace Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints
                     : meetingPoint.Robot2Id;
 
                 // One of the partitions would already contain the vertex id of the best connection, so that will be a redundant since duplicates can not happen because of HashSet
-                partitions[robotIdWithSmallestPartition].VertexIds.Add(shortestConnection.Item1.Id);
-                partitions[robotIdWithSmallestPartition].VertexIds.Add(shortestConnection.Item2.Id);
+                var partitionToReplace = partitions[robotIdWithSmallestPartition];
+                var newVertexIds = new HashSet<int>(partitionToReplace.VertexIds)
+                {
+                    shortestConnection.Item1.Id, shortestConnection.Item2.Id
+                };
+                partitions[robotIdWithSmallestPartition] = new PartitionInfo(partitionToReplace.RobotId, newVertexIds);
             }
 
             return partitions;

--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitionInfo.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitionInfo.cs
@@ -22,42 +22,107 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
+using Accord.Math;
 
 using Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints;
+using Maes.Utilities;
 
 namespace Maes.Map.Generators.Patrolling.Partitioning
 {
     public class PartitionInfo : IEquatable<PartitionInfo>
     {
-        public PartitionInfo(int robotId, HashSet<int> vertexIds)
+        public PartitionInfo(int robotId, IReadOnlyCollection<int> vertexIds)
         {
             RobotId = robotId;
             VertexIds = vertexIds;
         }
 
         public int RobotId { get; }
-        public HashSet<int> VertexIds { get; }
+        public IReadOnlyCollection<int> VertexIds { get; }
 
         public bool Equals(PartitionInfo other)
         {
             return RobotId == other.RobotId &&
                    VertexIds.SetEquals(other.VertexIds);
         }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((PartitionInfo)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(RobotId, VertexIds);
+        }
+
+        public static bool operator ==(PartitionInfo? left, PartitionInfo? right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(PartitionInfo? left, PartitionInfo? right)
+        {
+            return !Equals(left, right);
+        }
     }
 
-    public class HMPPartitionInfo : PartitionInfo, IEquatable<HMPPartitionInfo>
+    public sealed class HMPPartitionInfo : PartitionInfo, IEquatable<HMPPartitionInfo>, ICloneable<HMPPartitionInfo>
     {
-        public HMPPartitionInfo(PartitionInfo partitionInfo, List<MeetingPoint> meetingPoints) : base(partitionInfo.RobotId, partitionInfo.VertexIds)
+        public HMPPartitionInfo(PartitionInfo partitionInfo, IReadOnlyList<MeetingPoint> meetingPoints)
+            : base(partitionInfo.RobotId, partitionInfo.VertexIds)
         {
             MeetingPoints = meetingPoints;
         }
 
-        public List<MeetingPoint> MeetingPoints { get; }
+        public IReadOnlyList<MeetingPoint> MeetingPoints { get; }
+
+        public HMPPartitionInfo Clone()
+        {
+            // This class is immutable, therefore we can just return this.
+            return this;
+        }
 
         public bool Equals(HMPPartitionInfo other)
         {
-            return RobotId == other.RobotId &&
-                   VertexIds.SetEquals(other.VertexIds);
+            return base.Equals(other) && MeetingPoints.SequenceEqual(other.MeetingPoints);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || obj is HMPPartitionInfo other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(base.GetHashCode(), MeetingPoints);
+        }
+
+        public static bool operator ==(HMPPartitionInfo? left, HMPPartitionInfo? right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(HMPPartitionInfo? left, HMPPartitionInfo? right)
+        {
+            return !Equals(left, right);
         }
     }
 }

--- a/Assets/Scripts/Utilities/PartitionsExtensions.cs
+++ b/Assets/Scripts/Utilities/PartitionsExtensions.cs
@@ -29,7 +29,7 @@ namespace Maes.Utilities
             var combinationOfPartitions = partitionInfoByRobotId.Values.Combinations();
             foreach (var (partitionInfo1, partitionInfo2) in combinationOfPartitions)
             {
-                if (partitionInfo1.VertexIds.Overlaps(partitionInfo2.VertexIds))
+                if (partitionInfo1.VertexIds.Any(v => partitionInfo2.VertexIds.Contains(v)))
                 {
                     continue;
                 }


### PR DESCRIPTION
Clone the value when receiving it from a message. This stops reference types from leaking information.
This forces things to implement IClonable. However, if the class is immutable, it should just return this instead of cloning, to improve performance.

Depends on #355 