### PR TITLE
Multi-Instance simulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,41 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: build
 
+  build-server:
+    needs: setup
+    name: Build for Linux Server
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-StandaloneLinux64-Server-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-StandaloneLinux64-
+            Library-
+      - uses: actions/cache/restore@v4
+        with:
+          path: Assets/Packages
+          key: Packages-${{ hashFiles('Assets/NuGet.config') }}
+      - uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: StandaloneLinux64
+          projectPath: .
+          customParameters: -standaloneBuildSubtarget Server
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Build-StandaloneLinux64-Server
+          path: build
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Assets/Editor/CopyScript.cs
+++ b/Assets/Editor/CopyScript.cs
@@ -1,0 +1,30 @@
+using System.IO;
+
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+using UnityEngine;
+
+namespace Editor
+{
+    public class CopyScript : IPostprocessBuildWithReport
+    {
+        private const string RunScriptName = "run.sh";
+        private const string RunHeadlessScriptName = "run-headless.sh";
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            var projectPath = Directory.GetParent(Application.dataPath)!.ToString();
+
+            var outputDir = Directory.GetParent(report.summary.outputPath)!.ToString();
+
+            var runScriptPath = Path.Join(projectPath, "run-scripts", RunScriptName);
+            var runHeadlessScriptPath = Path.Join(projectPath, "run-scripts", RunHeadlessScriptName);
+
+            File.Copy(runScriptPath, Path.Join(outputDir, RunScriptName), true);
+            File.Copy(runHeadlessScriptPath, Path.Join(outputDir, RunHeadlessScriptName), true);
+        }
+
+        public int callbackOrder { get; }
+    }
+}

--- a/Assets/Editor/CopyScript.cs.meta
+++ b/Assets/Editor/CopyScript.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03d93cbad96d9074fb7509d770f189d4

--- a/Assets/Scripts/Experiments/Exploration/AvariceExperiment.cs
+++ b/Assets/Scripts/Experiments/Exploration/AvariceExperiment.cs
@@ -92,7 +92,7 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
 
 
             var random = new System.Random(1234);
@@ -127,7 +127,7 @@ namespace Maes.Experiments.Exploration
                         var regex = new Regex($@"avarice-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                                 mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                     buildingConfig,
@@ -149,7 +149,7 @@ namespace Maes.Experiments.Exploration
                         regex = new Regex($@"avarice-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnApart_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                                 collisionMap: buildingConfig,
@@ -167,7 +167,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -178,9 +178,9 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: $"delete-me",
                 robotConstraints: constraintsDict["Global"]));
 
-            simulator.PressPlayButton(); // Instantly enter play mode
+            var simulator = new MySimulator(scenarios);
 
-            //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+            simulator.PressPlayButton(); // Instantly enter play mode
         }
     }
 }

--- a/Assets/Scripts/Experiments/Exploration/AvariceExploratoryExperiment.cs
+++ b/Assets/Scripts/Experiments/Exploration/AvariceExploratoryExperiment.cs
@@ -19,6 +19,8 @@
 // 
 // Original repository: https://github.com/Molitany/MAES
 
+using System.Collections.Generic;
+
 using Maes.Algorithms.Exploration.Greed;
 using Maes.Algorithms.Exploration.Minotaur;
 using Maes.Map.Generators;
@@ -52,14 +54,15 @@ namespace Maes.Experiments.Exploration
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) =>
                     distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+
+            var scenarios = new List<MySimulationScenario>();
 
             var mapFromFile = PgmMapFileLoader.LoadMapFromFileIfPresent("blank_100.pgm");
             var random = new System.Random(1234);
             for (var i = 0; i < 10; i++)
             {
                 var val = random.Next(0, 1000000);
-                simulator.EnqueueScenario(new MySimulationScenario(val,
+                scenarios.Add(new MySimulationScenario(val,
                     mapSpawner: generator => generator.GenerateMap(mapFromFile, val),
                     robotConstraints: los,
                     statisticsFileName: $"mino_blank_{val}",
@@ -68,7 +71,7 @@ namespace Maes.Experiments.Exploration
                         5,
                         new Vector2Int(0, 0),
                         _ => new MinotaurAlgorithm(los, 4))));
-                simulator.EnqueueScenario(new MySimulationScenario(val,
+                scenarios.Add(new MySimulationScenario(val,
                     mapSpawner: generator => generator.GenerateMap(mapFromFile, val),
                     robotConstraints: los,
                     statisticsFileName: $"greed_blank_{val}",
@@ -80,7 +83,7 @@ namespace Maes.Experiments.Exploration
             }
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -91,6 +94,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: "delete-me",
                 robotConstraints: los));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/ExampleProgram.cs
+++ b/Assets/Scripts/Experiments/Exploration/ExampleProgram.cs
@@ -91,7 +91,8 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(1234);
             var randNumbers = new List<int>();
             for (var i = 0; i < 100; i++)
@@ -131,7 +132,7 @@ namespace Maes.Experiments.Exploration
                         foreach (var (algorithmName, algorithm) in algorithms)
                         {
 
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                  buildingConfig,
@@ -149,7 +150,7 @@ namespace Maes.Experiments.Exploration
                                 spawningPosList.Add(new Vector2Int(random.Next(0, size), random.Next(0, size)));
                             }
 
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                                  collisionMap: buildingConfig,
@@ -167,7 +168,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -178,6 +179,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: $"delete-me",
                 robotConstraints: robotConstraints));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/ExampleProgramOneRobotAndSimulation.cs
+++ b/Assets/Scripts/Experiments/Exploration/ExampleProgramOneRobotAndSimulation.cs
@@ -58,7 +58,6 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
             var random = new System.Random(randomSeed);
             const int robotCount = 1;
             const int size = 75;
@@ -76,7 +75,7 @@ namespace Maes.Experiments.Exploration
                 spawningPosList.Add(new Vector2Int(random.Next(-size / 2, size / 2), random.Next(-size / 2, size / 2)));
             }
 
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            var scenarios = new MySimulationScenario[] {new(seed: 123,
                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                  collisionMap: buildingConfig,
@@ -85,8 +84,9 @@ namespace Maes.Experiments.Exploration
                                                                  spawnPositions: spawningPosList,
                                                                  createAlgorithmDelegate: algorithm),
                                                              statisticsFileName: $"{algorithmName}-seed-{mapConfig.RandomSeed}-size-{size}-comms-{constraintName}-robots-{robotCount}-SpawnApart",
-                                                             robotConstraints: robotConstraints)
-            );
+                                                             robotConstraints: robotConstraints)};
+
+            var simulator = new MySimulator(scenarios);
 
             simulator.PressPlayButton(); // Instantly enter play mode
         }

--- a/Assets/Scripts/Experiments/Exploration/ExplorationExperimentBase.cs
+++ b/Assets/Scripts/Experiments/Exploration/ExplorationExperimentBase.cs
@@ -84,7 +84,9 @@ namespace Maes.Experiments.Exploration
                     { "greed", _ => new GreedAlgorithm() },
                     { "voronoi", seed => new VoronoiExplorationAlgorithm(seed, constraintsDict[constraintName].SlamRayTraceRange-1) }
                 };
-            var simulator = new MySimulator();
+
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(1234);
             var randNumbers = new List<int>();
             for (var i = 0; i < mapIterations; i++)
@@ -158,7 +160,7 @@ namespace Maes.Experiments.Exploration
                         var regex = new Regex($@"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether_.*\.csv");
                         if (((desiredSeed.HasValue && desiredSeed.Value == mapConfig.RandomSeed) && (desiredRobots.HasValue && desiredRobots == robotCount)) || (!desiredSeed.HasValue && !previousSimulations.Any(simulation => regex.IsMatch(simulation))))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                 buildingConfig,
@@ -172,7 +174,7 @@ namespace Maes.Experiments.Exploration
                         }
                         else
                         {
-                            simulator.EnqueueScenario(
+                            scenarios.Add(
                                 new MySimulationScenario(seed: 123,
                                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                                     robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
@@ -196,7 +198,7 @@ namespace Maes.Experiments.Exploration
                         regex = new Regex($@"{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnApart_.*\.csv");
                         if (((desiredSeed.HasValue && desiredSeed.Value == mapConfig.RandomSeed) && (desiredRobots.HasValue && desiredRobots == robotCount)) || (!desiredSeed.HasValue && !previousSimulations.Any(simulation => regex.IsMatch(simulation))))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                                 collisionMap: buildingConfig,
@@ -210,7 +212,7 @@ namespace Maes.Experiments.Exploration
                         }
                         else
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                 mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                     collisionMap: buildingConfig,
@@ -234,7 +236,7 @@ namespace Maes.Experiments.Exploration
                         var regex = new Regex($@"{mapType}-{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                 buildingConfig,
@@ -248,7 +250,7 @@ namespace Maes.Experiments.Exploration
                         }
                         else
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                 mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                     buildingConfig,
@@ -270,7 +272,7 @@ namespace Maes.Experiments.Exploration
                         regex = new Regex($@"{mapType}-{algorithmName}-seed-{mapConfig.RandomSeed}-mapConfig.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnApart_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                                 collisionMap: buildingConfig,
@@ -284,7 +286,7 @@ namespace Maes.Experiments.Exploration
                         }
                         else
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                 mapSpawner: generator => generator.GenerateMap(mapConfig),
                                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                     collisionMap: buildingConfig,
@@ -301,7 +303,7 @@ namespace Maes.Experiments.Exploration
             }
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -312,6 +314,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: $"delete-me",
                 robotConstraints: constraintsDict[constraintName]));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/ExplorationTimeoutTest.cs
+++ b/Assets/Scripts/Experiments/Exploration/ExplorationTimeoutTest.cs
@@ -92,13 +92,14 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
+            var scenarios = new List<MySimulationScenario>();
+
             var algorithms = new Dictionary<string, RobotSpawner.CreateAlgorithmDelegate>
                 {
                     { "tnf", seed => new TnfExplorationAlgorithm(1, 10, seed) },
                     { "minotaur", _ => new MinotaurAlgorithm(constraintsDict[constraintName], 2) },
                     { "greed", _ => new GreedAlgorithm() }
                 };
-            var simulator = new MySimulator();
             var random = new System.Random(1234);
             var randNumbers = new List<int>();
             for (var i = 0; i < 100; i++)
@@ -139,7 +140,7 @@ namespace Maes.Experiments.Exploration
 
                     if (robotCount == 5 && mapConfig.RandomSeed == 585462)
                     {
-                        simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                        scenarios.Add(new MySimulationScenario(seed: 123,
                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                 buildingConfig,
@@ -152,7 +153,7 @@ namespace Maes.Experiments.Exploration
                     }
                     else
                     {
-                        simulator.EnqueueScenario(
+                        scenarios.Add(
                         new MySimulationScenario(seed: 123,
                             mapSpawner: generator => generator.GenerateMap(mapConfig),
                             robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
@@ -170,7 +171,7 @@ namespace Maes.Experiments.Exploration
                         spawningPosHashSet.Add(new Vector2Int(random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2), random.Next(-mapConfig.HeightInTiles / 2, mapConfig.HeightInTiles / 2)));
                     }
 
-                    simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                    scenarios.Add(new MySimulationScenario(seed: 123,
                                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                                     robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                         collisionMap: buildingConfig,
@@ -185,7 +186,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                     buildingConfig,
@@ -196,6 +197,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: $"delete-me",
                 robotConstraints: constraintsDict[constraintName]));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/MinotaurExperiments.cs
+++ b/Assets/Scripts/Experiments/Exploration/MinotaurExperiments.cs
@@ -91,8 +91,7 @@ namespace Maes.Experiments.Exploration
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) =>
                     distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
-
+            var scenarios = new List<MySimulationScenario>();
 
             var random = new System.Random(1234);
             var randNumbers = new List<int>();
@@ -126,7 +125,7 @@ namespace Maes.Experiments.Exploration
                         var regex = new Regex($@"minotaur-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                  buildingConfig,
@@ -147,7 +146,7 @@ namespace Maes.Experiments.Exploration
                         regex = new Regex($@"minotaur-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnApart.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                          mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                          robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                              collisionMap: buildingConfig,
@@ -165,7 +164,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -176,6 +175,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: "delete-me",
                 robotConstraints: constraintsDict["Global"]));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/TnfExperiments.cs
+++ b/Assets/Scripts/Experiments/Exploration/TnfExperiments.cs
@@ -92,7 +92,8 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
 
 
             var random = new System.Random(1234);
@@ -127,7 +128,7 @@ namespace Maes.Experiments.Exploration
                         var regex = new Regex($@"tnf-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnTogether_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                          mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                          robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                              buildingConfig,
@@ -148,7 +149,7 @@ namespace Maes.Experiments.Exploration
                         regex = new Regex($@"tnf-seed-{mapConfig.RandomSeed}-mapConfig\.HeightInTiles-{mapConfig.HeightInTiles}-comms-{constraintName}-robots-{robotCount}-SpawnApart_.*\.csv");
                         if (!previousSimulations.Any(simulation => regex.IsMatch(simulation)))
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                          mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                          robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                              collisionMap: buildingConfig,
@@ -166,7 +167,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -177,6 +178,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: "delete-me",
                 robotConstraints: constraintsDict["Global"]));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Exploration/WallFollowerExperiment.cs
+++ b/Assets/Scripts/Experiments/Exploration/WallFollowerExperiment.cs
@@ -89,7 +89,8 @@ namespace Maes.Experiments.Exploration
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
             var randNumbers = new List<int>();
             for (var i = 0; i < 100; i++)
@@ -126,7 +127,7 @@ namespace Maes.Experiments.Exploration
                     {
                         foreach (var (algorithmName, algorithm) in algorithms)
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                                  buildingConfig,
@@ -144,7 +145,7 @@ namespace Maes.Experiments.Exploration
                                 spawningPosList.Add(new Vector2Int(random.Next(-size / 2, size / 2), random.Next(-size / 2, size / 2)));
                             }
 
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
                                                                                  collisionMap: buildingConfig,
@@ -162,7 +163,7 @@ namespace Maes.Experiments.Exploration
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -173,6 +174,7 @@ namespace Maes.Experiments.Exploration
                 statisticsFileName: $"delete-me",
                 robotConstraints: robotConstraints));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Patrolling/CognitiveCoordinatedExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/CognitiveCoordinatedExperiment.cs
@@ -59,7 +59,8 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -72,7 +73,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -88,6 +89,7 @@ namespace Maes.Experiments.Patrolling
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether")
             );
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/CognitiveCoordinatedVirtualStigmergyExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/CognitiveCoordinatedVirtualStigmergyExperiment.cs
@@ -56,7 +56,8 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -69,7 +70,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -85,6 +86,7 @@ namespace Maes.Experiments.Patrolling
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether")
             );
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/CommonMapCRExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/CommonMapCRExperiment.cs
@@ -59,7 +59,8 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
 
             var algoName = "conscientious_reactive";
@@ -89,7 +90,7 @@ namespace Maes.Experiments.Patrolling
             {
                 var mapName = mapNames[mapIndex];
                 var val = random.Next(0, 1000000);
-                simulator.EnqueueScenario(
+                scenarios.Add(
                     new MySimulationScenario(
                         seed: val,
                         totalCycles: 4,
@@ -116,6 +117,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSizeX / 2, mapSizeX / 2), random.Next(-mapSizeY / 2, mapSizeY / 2)));
             }
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/ConscientiousReactiveExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/ConscientiousReactiveExperiment.cs
@@ -101,7 +101,6 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -117,8 +116,9 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
-                new MySimulationScenario(
+            var scenarios = new MySimulationScenario[]
+            {
+                new(
                     seed: 123,
                     totalCycles: 4,
                     stopAfterDiff: false,
@@ -130,11 +130,9 @@ namespace Maes.Experiments.Patrolling
                         createAlgorithmDelegate: (_) => new ConscientiousReactiveAlgorithm()),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints,
-                    statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether")
-            );
-
-            simulator.EnqueueScenario(
-                new MySimulationScenario(
+                    statisticsFileName:
+                    $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether"),
+                new(
                     seed: 123,
                     totalCycles: 4,
                     stopAfterDiff: false,
@@ -146,9 +144,11 @@ namespace Maes.Experiments.Patrolling
                         createAlgorithmDelegate: (_) => new ConscientiousReactiveAlgorithm()),
                     mapSpawner: generator => generator.GenerateMap(mapConfig2),
                     robotConstraints: robotConstraints,
-                    statisticsFileName: $"{algoName}-seed-{mapConfig2.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether")
-            );
+                    statisticsFileName:
+                    $"{algoName}-seed-{mapConfig2.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether"),
+            };
 
+            var simulator = new MySimulator(scenarios);
 
             simulator.PressPlayButton(); // Instantly enter play mode
         }

--- a/Assets/Scripts/Experiments/Patrolling/ConscientiousReactiveExperimentWithFaultInjection.cs
+++ b/Assets/Scripts/Experiments/Patrolling/ConscientiousReactiveExperimentWithFaultInjection.cs
@@ -101,7 +101,8 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -116,7 +117,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -133,6 +134,7 @@ namespace Maes.Experiments.Patrolling
             );
 
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/HMPPatrollingExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPatrollingExperiment.cs
@@ -20,6 +20,8 @@
 // Mads Beyer Mogensen,
 // Puvikaran Santhirasegaram
 
+using System.Collections.Generic;
+
 using Maes.Algorithms.Patrolling;
 using Maes.Map.Generators;
 using Maes.Map.Generators.Patrolling.Partitioning;
@@ -60,11 +62,12 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
 
             var mapConfig = new BuildingMapConfig(123, widthInTiles: mapSize, heightInTiles: mapSize, brokenCollisionMap: false);
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: seed,
                     totalCycles: 4,
@@ -81,6 +84,7 @@ namespace Maes.Experiments.Patrolling
                     patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
             );
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/HenrikExample.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HenrikExample.cs
@@ -89,7 +89,7 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
             var random = new System.Random(1234);
             var randNumbers = new List<int>();
             for (var i = 0; i < 100; i++)
@@ -120,7 +120,7 @@ namespace Maes.Experiments.Patrolling
                     foreach (var (algorithmName, algorithm) in algorithms)
                     {
 
-                        simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                        scenarios.Add(new MySimulationScenario(seed: 123,
                                                                          mapSpawner: generator => generator.GenerateMap(mapConfig),
                                                                          robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                              buildingConfig,
@@ -137,7 +137,7 @@ namespace Maes.Experiments.Patrolling
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 mapSpawner: generator => generator.GenerateMap(dumpMap),
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                                                                  buildingConfig,
@@ -148,6 +148,7 @@ namespace Maes.Experiments.Patrolling
                 statisticsFileName: $"delete-me",
                 robotConstraints: robotConstraints));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Patrolling/HeuristicConscientiousReactiveExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HeuristicConscientiousReactiveExperiment.cs
@@ -68,7 +68,7 @@ namespace Maes.Experiments.Patrolling
                 materialCommunication: true)
             };
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -84,7 +84,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -101,7 +101,7 @@ namespace Maes.Experiments.Patrolling
                 )
             );
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -118,6 +118,7 @@ namespace Maes.Experiments.Patrolling
                 )
             );
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/PartitionedConscientiousReactiveExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/PartitionedConscientiousReactiveExperiment.cs
@@ -59,7 +59,7 @@ namespace Maes.Experiments.Patrolling
                 materialCommunication: true,
                 robotCollisions: false);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
             var random = new System.Random(12345);
             var mapSize = 100;
 
@@ -73,7 +73,7 @@ namespace Maes.Experiments.Patrolling
                 spawningPosList.Add(new Vector2Int(random.Next(-mapSize / 2, mapSize / 2), random.Next(-mapSize / 2, mapSize / 2)));
             }
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 10,
@@ -90,7 +90,7 @@ namespace Maes.Experiments.Patrolling
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether")
             );
 
-            simulator.EnqueueScenario(
+            scenarios.Add(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 10,
@@ -108,6 +108,7 @@ namespace Maes.Experiments.Patrolling
             );
 
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Experiments/Patrolling/RandomReactiveExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/RandomReactiveExperiment.cs
@@ -95,7 +95,8 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls <= 0);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
+
             var random = new System.Random(12345);
             var randNumbers = new List<int>();
             for (var i = 0; i < 100; i++)
@@ -128,7 +129,7 @@ namespace Maes.Experiments.Patrolling
                     {
                         foreach (var (algorithmName, algorithm) in algorithms)
                         {
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              totalCycles: 3,
                                                                              stopAfterDiff: true,
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
@@ -148,7 +149,7 @@ namespace Maes.Experiments.Patrolling
                                 spawningPosList.Add(new Vector2Int(random.Next(-size / 2, size / 2), random.Next(-size / 2, size / 2)));
                             }
 
-                            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+                            scenarios.Add(new MySimulationScenario(seed: 123,
                                                                              totalCycles: 3,
                                                                              stopAfterDiff: true,
                                                                              robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsAtPositions(
@@ -168,7 +169,7 @@ namespace Maes.Experiments.Patrolling
 
             //Just code to make sure we don't get too many maps of the last one in the experiment
             var dumpMap = new BuildingMapConfig(-1, widthInTiles: 50, heightInTiles: 50, brokenCollisionMap: false);
-            simulator.EnqueueScenario(new MySimulationScenario(seed: 123,
+            scenarios.Add(new MySimulationScenario(seed: 123,
                 totalCycles: 3,
                 stopAfterDiff: true,
                 robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
@@ -181,6 +182,7 @@ namespace Maes.Experiments.Patrolling
                 robotConstraints: robotConstraints,
                 statisticsFileName: "delete-me"));
 
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
 
             //simulator.GetSimulationManager().AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/Assets/Scripts/Experiments/Patrolling/cs-25-ds-10-16Experiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/cs-25-ds-10-16Experiment.cs
@@ -56,7 +56,7 @@ namespace Maes.Experiments.Patrolling
                 agentRelativeSize: 0.6f,
                 calculateSignalTransmissionProbability: (_, _) => true);
 
-            var simulator = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
             var random = new System.Random(12345);
             const int seed = 123;
             const int cycles = 100;
@@ -112,7 +112,7 @@ namespace Maes.Experiments.Patrolling
                             switch (mapConfig)
                             {
                                 case Tile[,]:
-                                    simulator.EnqueueScenario(
+                                    scenarios.Add(
                                         new MySimulationScenario(
                                             seed: seed,
                                             totalCycles: cycles,
@@ -124,14 +124,14 @@ namespace Maes.Experiments.Patrolling
                                                 suggestedStartingPoint: pos,
                                                 numberOfRobots: robotCount,
                                                 createAlgorithmDelegate: _ => redisAlg),
-                                            mapSpawner: generator => generator.GenerateMap(mapConfig as Tile[,], seed,
+                                            mapSpawner: generator => generator.GenerateMap((Tile[,])mapConfig, seed,
                                                 brokenCollisionMap: false),
                                             robotConstraints: robotConstraints,
                                             statisticsFileName: $"{redisName}-seed-{seed}-map-{mapName}-partitions-{partitions}-comms-{constraintName}-robots-{robotCount}-SpawnApart")
                                     );
                                     break;
                                 case CaveMapConfig:
-                                    simulator.EnqueueScenario(
+                                    scenarios.Add(
                                         new MySimulationScenario(
                                             seed: seed,
                                             totalCycles: cycles,
@@ -148,7 +148,7 @@ namespace Maes.Experiments.Patrolling
                                     );
                                     break;
                                 case BuildingMapConfig:
-                                    simulator.EnqueueScenario(
+                                    scenarios.Add(
                                         new MySimulationScenario(
                                             seed: seed,
                                             totalCycles: cycles,
@@ -170,6 +170,8 @@ namespace Maes.Experiments.Patrolling
                     }
                 }
             }
+
+            var simulator = new MySimulator(scenarios);
             simulator.PressPlayButton(); // Instantly enter play mode
         }
     }

--- a/Assets/Scripts/Simulation/Exploration/ExplorationSimulator.cs
+++ b/Assets/Scripts/Simulation/Exploration/ExplorationSimulator.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 
 using Maes.Algorithms.Exploration;
-using Maes.UI;
 
 using UnityEngine;
 
@@ -9,34 +8,13 @@ namespace Maes.Simulation.Exploration
 {
     public sealed class ExplorationSimulator : Simulator<ExplorationSimulation, IExplorationAlgorithm, ExplorationSimulationScenario>
     {
-        public ExplorationSimulator(bool autoMaxSpeedInBatchMode = true) : base(autoMaxSpeedInBatchMode) { }
+        public ExplorationSimulator(IReadOnlyList<ExplorationSimulationScenario> scenarios, bool autoMaxSpeedInBatchMode = true) : base(scenarios, autoMaxSpeedInBatchMode)
+        {
+        }
+
         protected override GameObject LoadSimulatorGameObject()
         {
             return Resources.Load<GameObject>("Exploration_MAEPS");
         }
-
-        /// <summary>
-        /// This method is used to start the simulation in a predefined configuration that will change depending on	
-        /// whether the simulation is in ros mode or not.	
-        /// </summary>	
-        public void DefaultStart(bool isRosMode = false)
-        {
-            GlobalSettings.IsRosMode = isRosMode;
-            IEnumerable<ExplorationSimulationScenario> generatedScenarios;
-            if (GlobalSettings.IsRosMode)
-            {
-                generatedScenarios = ExplorationScenarioGenerator.GenerateROS2Scenario();
-            }
-            else
-            {
-                generatedScenarios = ExplorationScenarioGenerator.GenerateYoutubeVideoScenarios();
-            }
-            EnqueueScenarios(generatedScenarios);
-            if (Application.isBatchMode)
-            {
-                SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
-            }
-        }
-
     }
 }

--- a/Assets/Scripts/Simulation/Patrolling/PatrollingSimulator.cs
+++ b/Assets/Scripts/Simulation/Patrolling/PatrollingSimulator.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Maes.Algorithms.Patrolling;
 
 using UnityEngine;
@@ -6,6 +8,10 @@ namespace Maes.Simulation.Patrolling
 {
     public sealed class PatrollingSimulator : Simulator<PatrollingSimulation, IPatrollingAlgorithm, PatrollingSimulationScenario>
     {
+        public PatrollingSimulator(IReadOnlyList<PatrollingSimulationScenario> scenarios, bool autoMaxSpeedInBatchMode = true) : base(scenarios, autoMaxSpeedInBatchMode)
+        {
+        }
+
         protected override GameObject LoadSimulatorGameObject()
         {
             return Resources.Load<GameObject>("Patrolling_MAEPS");

--- a/Assets/Scripts/Simulation/SimulationBase.cs
+++ b/Assets/Scripts/Simulation/SimulationBase.cs
@@ -205,6 +205,7 @@ namespace Maes.Simulation
 
         public void UpdateDebugInfo()
         {
+#if !UNITY_SERVER
             if (_selectedRobot is not null)
             {
                 if (GlobalSettings.IsRosMode)
@@ -223,6 +224,7 @@ namespace Maes.Simulation
             {
                 SimInfoUIController.UpdateTagDebugInfo(_selectedTag.GetDebugInfo());
             }
+#endif
         }
 
         public virtual void OnSimulationFinished()

--- a/Assets/Scripts/Simulation/SimulationManager.cs
+++ b/Assets/Scripts/Simulation/SimulationManager.cs
@@ -30,6 +30,8 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UIElements;
 
+using Debug = UnityEngine.Debug;
+
 namespace Maes.Simulation
 {
     public abstract class SimulationManager<TSimulation, TAlgorithm, TScenario> : MonoBehaviour, ISimulationManager
@@ -125,6 +127,7 @@ namespace Maes.Simulation
 
         private void Update()
         {
+#if !UNITY_SERVER
             var keyboard = Keyboard.current;
             if (keyboard.leftShiftKey.isPressed || keyboard.rightShiftKey.isPressed)
             {
@@ -145,6 +148,7 @@ namespace Maes.Simulation
                     AttemptSetPlayState(SimulationPlayState.Step);
                 }
             }
+#endif
 
             if (CurrentSimulation == null)
             {
@@ -269,9 +273,11 @@ namespace Maes.Simulation
 
         private void UpdateStatisticsUI()
         {
+#if !UNITY_SERVER
             SimulationInfoUIController.UpdateStatistics(CurrentSimulation);
             CurrentSimulation?.UpdateDebugInfo();
             CurrentSimulation?.Tracker.UIUpdate();
+#endif
         }
 
         public void RemoveCurrentSimulation()

--- a/Assets/Scripts/UI/CameraController.cs
+++ b/Assets/Scripts/UI/CameraController.cs
@@ -82,6 +82,7 @@ namespace Maes.UI
         // Start is called before the first frame update
         private void Start()
         {
+#if !UNITY_SERVER
             _simulationManager = simulationManagerObject.GetComponent<ISimulationManager>();
 
             _leftButton = uiDocument.rootVisualElement.Q<Button>("MoveLeftButton");
@@ -109,6 +110,7 @@ namespace Maes.UI
             newRotation = transform.rotation;
             CameraInitialization();
             stickyCam = false;
+#endif
         }
 
         private void HandleButton(Button button, Direction direction)
@@ -144,6 +146,7 @@ namespace Maes.UI
         // Update is called once per frame
         private void Update()
         {
+#if !UNITY_SERVER
             var mouseWorldPosition = GetMouseWorldPosition();
             if (mouseWorldPosition != null)
             {
@@ -171,6 +174,7 @@ namespace Maes.UI
                 }
                 _simulationManager.CurrentSimulation?.ClearVisualTags();
             }
+#endif
         }
 
         private void HandleCameraSelect()

--- a/Assets/Scripts/UI/SimulationInfoUIControllers/SimulationInfoUIControllerBase.cs
+++ b/Assets/Scripts/UI/SimulationInfoUIControllers/SimulationInfoUIControllerBase.cs
@@ -62,6 +62,7 @@ namespace Maes.UI.SimulationInfoUIControllers
 
         private void Start()
         {
+#if !UNITY_SERVER
             _stickyCameraButton = modeSpecificUiDocument.rootVisualElement.Q<Button>("SelectedRobotStickyCameraButton");
 
             _robotControllerValueLabel = modeSpecificUiDocument.rootVisualElement.Q<Label>("RobotControllerValueLabel");
@@ -77,6 +78,7 @@ namespace Maes.UI.SimulationInfoUIControllers
             });
 
             AfterStart();
+#endif
         }
 
         public virtual void ClearSelectedRobot()

--- a/Assets/Scripts/UI/Tooltip.cs
+++ b/Assets/Scripts/UI/Tooltip.cs
@@ -34,9 +34,11 @@ namespace Maes.UI
 
         private void Awake()
         {
+#if !UNITY_SERVER
             s_instance = this;
             _tooltip = GetComponent<UIDocument>().rootVisualElement.Q<Label>("Tooltip");
             HideTooltip();
+#endif
         }
 
         private void ShowTooltip(string text)
@@ -52,20 +54,26 @@ namespace Maes.UI
 
         private void Update()
         {
+#if !UNITY_SERVER
             // Have the tooltip follow the mouse-pointer around.
             var mousePosition = Mouse.current.position.ReadValue();
             _tooltip.style.top = Screen.height - mousePosition.y;
             _tooltip.style.left = mousePosition.x;
+#endif
         }
 
         public static void ShowTooltip_Static(string text)
         {
+#if !UNITY_SERVER
             s_instance.ShowTooltip(text);
+#endif
         }
 
         public static void HideTooltip_Static()
         {
+#if !UNITY_SERVER
             s_instance.HideTooltip();
+#endif
         }
     }
 }

--- a/Assets/Tests/PlayModeTests/Algorithms/Exploration/MinotaurDoorwayTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Exploration/MinotaurDoorwayTest.cs
@@ -104,8 +104,7 @@ namespace Tests.PlayModeTests.Algorithms.Exploration
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _explorationSimulation = _maes.SimulationManager.CurrentSimulation;
         }
 

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/Components/StartupTests.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/Components/StartupTests.cs
@@ -22,13 +22,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
     {
         private PatrollingSimulator _simulator;
 
-        private List<TestingAlgorithm> _algorithms;
+        private readonly List<TestingAlgorithm> _algorithms = new();
 
-        [SetUp]
-        public void Setup()
+        private void Setup(IReadOnlyList<PatrollingSimulationScenario> scenarios)
         {
-            _simulator = new PatrollingSimulator();
-            _algorithms = new List<TestingAlgorithm>();
+            _simulator = new PatrollingSimulator(scenarios);
         }
 
         [TearDown]
@@ -41,7 +39,8 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
         [Test(ExpectedResult = null)]
         public IEnumerator TestComponent()
         {
-            EnqueueScenario(BitmapUtilities.CreateEmptyBitmap(16, 16), new Vector2Int(1, 8), new Vector2Int(15, 8));
+            var scenario = CreateScenario(BitmapUtilities.CreateEmptyBitmap(16, 16), new Vector2Int(1, 8), new Vector2Int(15, 8));
+            Setup(new[] { scenario });
             _simulator.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
 
             // This waits an unknown amount of ticks
@@ -71,13 +70,13 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
         }
 
 
-        private void EnqueueScenario(Bitmap bitmap, params Vector2Int[] robotPositions)
+        private PatrollingSimulationScenario CreateScenario(Bitmap bitmap, params Vector2Int[] robotPositions)
         {
             var tilemap = Utilities.BitmapToTilemap(bitmap);
 
             var robotSpawnPositions = robotPositions.ToList();
 
-            _simulator.EnqueueScenario(new PatrollingSimulationScenario(
+            return new PatrollingSimulationScenario(
                 seed: 123,
                 totalCycles: 4,
                 stopAfterDiff: false,
@@ -93,7 +92,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.Components
                 mapSpawner: mapSpawner => mapSpawner.GenerateMap(tilemap, 123, brokenCollisionMap: false),
                 CreateRobotConstraints(),
                 patrollingMapFactory: map => new PatrollingMap(new[] { new Vertex(0, new Vector2Int(4, 4)) }, map)
-            ));
+            );
         }
 
         private static RobotConstraints CreateRobotConstraints()

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingOwnPartitionTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingOwnPartitionTest.cs
@@ -75,7 +75,6 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
 
         private void CreateAndEnqueueScenario()
         {
-            _maes = new PatrollingSimulator();
 
             var robotConstraints = new RobotConstraints(
                 senseNearbyAgentsRange: 5f,
@@ -94,7 +93,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
 
             var mapConfig = new BuildingMapConfig(123, widthInTiles: MapSize, heightInTiles: MapSize, brokenCollisionMap: false);
 
-            _maes.EnqueueScenario(
+            var scenarios = new[] {(
                 new PatrollingSimulationScenario(
                     seed: Seed,
                     totalCycles: TotalCycles,
@@ -109,7 +108,9 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
                     robotConstraints: robotConstraints,
                     statisticsFileName: $"test",
                     patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
-            );
+            )};
+
+            _maes = new PatrollingSimulator(scenarios);
         }
 
         private class TrackerVertices

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/MeetAtTheMeetingPointTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/MeetAtTheMeetingPointTest.cs
@@ -37,12 +37,6 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
             calculateSignalTransmissionProbability: (totalDistance, distanceThroughWalls) => distanceThroughWalls == 0.0 && totalDistance <= 5.0f);
 
 
-        [SetUp]
-        public void Setup()
-        {
-            _simulator = new PatrollingSimulator();
-        }
-
         [TearDown]
         public void ClearSimulator()
         {
@@ -64,7 +58,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
 
             var spawnAtVertexPosition = patrollingMap.Vertices[spawnAtVertexId].Position;
 
-            _simulator.EnqueueScenario(
+            var scenario =
                 new PatrollingSimulationScenario(
                     seed: seed,
                     totalCycles: totalCycles,
@@ -79,7 +73,9 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
                     patrollingMapFactory: _ => patrollingMap,
                     robotConstraints: _robotConstraints,
                     statisticsFileName: $"{algoName}-seed-{seed}-size-{mapWidth}-robots-{robotCount}-RandomRobotSpawn")
-            );
+            ;
+
+            _simulator = new PatrollingSimulator(new[] { scenario });
 
             return _simulator.SimulationManager.CurrentSimulation;
         }

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingAlgorithmTest.cs
@@ -31,7 +31,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
             var algoName = algorithm.AlgorithmName;
             var spawningPosList = ScenarioBuilderUtilities.GenerateRandomSpawningPositions(random, mapSize, RobotCount);
 
-            _maes.EnqueueScenario(
+            var scenarios = new[] {(
                 new MySimulationScenario(
                     seed: seed,
                     totalCycles: 4,
@@ -44,7 +44,10 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                         createAlgorithmDelegate: (_) => algorithm),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints, statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{RobotCount}-RandomRobotSpawn")
-            );
+            )};
+
+            _maes = new MySimulator(scenarios);
+
             return _maes.SimulationManager.CurrentSimulation;
         }
 
@@ -59,7 +62,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
             var algoName = algorithm.AlgorithmName;
             var spawningPosList = ScenarioBuilderUtilities.GenerateRandomSpawningPositions(random, mapSize, RobotCount);
 
-            _maes.EnqueueScenario(
+            var scenarios = new[] {(
                 new MySimulationScenario(
                     seed: seed,
                     totalCycles: 4,
@@ -73,14 +76,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints, statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{RobotCount}-RandomRobotSpawn",
                     patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
-            );
-            return _maes.SimulationManager.CurrentSimulation;
-        }
+            )};
 
-        [SetUp]
-        public void Setup()
-        {
-            _maes = new MySimulator();
+            _maes = new MySimulator(scenarios);
+
+            return _maes.SimulationManager.CurrentSimulation;
         }
 
         [TearDown]

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingSimulatorBuildingMapTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingSimulatorBuildingMapTest.cs
@@ -20,7 +20,6 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
 
         private void InitializeTestingSimulator()
         {
-            _maes = new MySimulator();
             var random = new System.Random(12345);
             var mapSize = 50;
 
@@ -32,7 +31,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
             const int robotCount = 1;
             var spawningPosList = ScenarioBuilderUtilities.GenerateRandomSpawningPositions(random, mapSize, robotCount);
 
-            _maes.EnqueueScenario(
+            var scenarios = new[] {(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -46,7 +45,8 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints,
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-RandomRobotSpawn")
-            );
+            )};
+            _maes = new MySimulator(scenarios);
             _simulation = _maes.SimulationManager.CurrentSimulation;
         }
 

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingSimulatorCaveMapTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/PatrollingSimulatorCaveMapTest.cs
@@ -20,7 +20,6 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
 
         private void InitializeTestingSimulator()
         {
-            _maes = new MySimulator();
             var random = new System.Random(12345);
             var mapSize = 50;
 
@@ -32,7 +31,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
             const int robotCount = 1;
             var spawningPosList = ScenarioBuilderUtilities.GenerateRandomSpawningPositions(random, mapSize, robotCount);
 
-            _maes.EnqueueScenario(
+            var scenarios = new[] {(
                 new MySimulationScenario(
                     seed: 123,
                     totalCycles: 4,
@@ -45,7 +44,10 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling
                         createAlgorithmDelegate: (_) => algorithm),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints, statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-RandomRobotSpawn")
-            );
+            )};
+
+            _maes = new MySimulator(scenarios);
+
             _simulation = _maes.SimulationManager.CurrentSimulation;
         }
 

--- a/Assets/Tests/PlayModeTests/CommunicationTest.cs
+++ b/Assets/Tests/PlayModeTests/CommunicationTest.cs
@@ -92,8 +92,7 @@ namespace Tests.PlayModeTests
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _explorationSimulation = _maes.SimulationManager.CurrentSimulation;
 
             // The first robot will broadcast immediatealy

--- a/Assets/Tests/PlayModeTests/EstimateTickTest/EstimateTestStraightPath.cs
+++ b/Assets/Tests/PlayModeTests/EstimateTickTest/EstimateTestStraightPath.cs
@@ -47,8 +47,7 @@ namespace Tests.PlayModeTests.EstimateTickTest
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _robot = _simulationBase.Robots[0];
         }

--- a/Assets/Tests/PlayModeTests/EstimateTickTest/EstimateTestTurnsPath.cs
+++ b/Assets/Tests/PlayModeTests/EstimateTickTest/EstimateTestTurnsPath.cs
@@ -66,8 +66,8 @@ namespace Tests.PlayModeTests.EstimateTickTest
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario }, autoMaxSpeedInBatchMode: false);
+            _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.Paused);
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _robot = _simulationBase.Robots[0];
         }

--- a/Assets/Tests/PlayModeTests/EstimateTickTest/OverEstimateTestStraightPath.cs
+++ b/Assets/Tests/PlayModeTests/EstimateTickTest/OverEstimateTestStraightPath.cs
@@ -29,7 +29,7 @@ namespace Tests.PlayModeTests.EstimateTickTest
 
         public OverEstimateTestStraightPath(float relativeMoveSpeed)
         {
-            _robotConstraints = new RobotConstraints(relativeMoveSpeed: relativeMoveSpeed, mapKnown: true);
+            _robotConstraints = new RobotConstraints(relativeMoveSpeed: relativeMoveSpeed, mapKnown: true, slamRayTraceRange: 0);
         }
 
         [SetUp]
@@ -47,8 +47,7 @@ namespace Tests.PlayModeTests.EstimateTickTest
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _robot = _simulationBase.Robots[0];
         }

--- a/Assets/Tests/PlayModeTests/EstimateTickTest/OverEstimateTestTurnsPath.cs
+++ b/Assets/Tests/PlayModeTests/EstimateTickTest/OverEstimateTestTurnsPath.cs
@@ -42,7 +42,7 @@ namespace Tests.PlayModeTests.EstimateTickTest
 
         public OverEstimateTestTurnsPath(float relativeMoveSpeed, int x, int y)
         {
-            _robotConstraints = new RobotConstraints(relativeMoveSpeed: relativeMoveSpeed, mapKnown: true);
+            _robotConstraints = new RobotConstraints(relativeMoveSpeed: relativeMoveSpeed, mapKnown: true, slamRayTraceRange: 0);
             _targetTile = new Vector2Int(x, y);
         }
 
@@ -66,8 +66,7 @@ namespace Tests.PlayModeTests.EstimateTickTest
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _robot = _simulationBase.Robots[0];
         }

--- a/Assets/Tests/PlayModeTests/ExplorationCsvDataWriterTest.cs
+++ b/Assets/Tests/PlayModeTests/ExplorationCsvDataWriterTest.cs
@@ -52,8 +52,7 @@ namespace Tests.PlayModeTests
                     _ => new TestingAlgorithm()
                     ));
 
-            _maes = new ExplorationSimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new ExplorationSimulator(new[] { testingScenario });
             _explorationSimulation = _maes.SimulationManager.CurrentSimulation;
         }
 

--- a/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs
+++ b/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/CheckMultipleScenarioCanBeRunWithoutFailFaultInjectionTest.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 
 using Maes.FaultInjections.DestroyRobots;
 using Maes.Robot;
@@ -45,7 +46,7 @@ namespace Tests.PlayModeTests.FaultInjections.DestroyRobots
         [SetUp]
         public void InitializeTestingSimulator()
         {
-            _maes = new MySimulator();
+            var scenarios = new List<MySimulationScenario>();
             for (var i = 0; i < _scenarioToRun; i++)
             {
                 var testingScenario = new MySimulationScenario(RandomSeed,
@@ -55,8 +56,10 @@ namespace Tests.PlayModeTests.FaultInjections.DestroyRobots
                     robotSpawner: (map, spawner) => spawner.SpawnRobotsTogether(map, RandomSeed, _robotsToSpawn,
                         Vector2Int.zero, _ => new TestingAlgorithm()),
                     faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToDestroy));
-                _maes.EnqueueScenario(testingScenario);
+                scenarios.Add(testingScenario);
             }
+
+            _maes = new MySimulator(scenarios);
         }
 
         [TearDown]

--- a/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs
+++ b/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomEveryTickFaultInjectionTest.cs
@@ -53,8 +53,7 @@ namespace Tests.PlayModeTests.FaultInjections.DestroyRobots.Random
                     Vector2Int.zero, _ => new TestingAlgorithm()),
                 faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToDestroy));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
         }
 

--- a/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs
+++ b/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/Random/DestroyRobotsRandomZeroProbabilityFaultInjectionTest.cs
@@ -50,8 +50,7 @@ namespace Tests.PlayModeTests.FaultInjections.DestroyRobots.Random
                     Vector2Int.zero, _ => new TestingAlgorithm()),
                 faultInjection: new DestroyRobotsRandomFaultInjection(RandomSeed, Probability, InvokeEvery, _robotsToSpawn));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
         }
 

--- a/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs
+++ b/Assets/Tests/PlayModeTests/FaultInjections/DestroyRobots/SpecificTick/DestroyRobotsAtTicksFaultInjectionTest.cs
@@ -84,8 +84,7 @@ namespace Tests.PlayModeTests.FaultInjections.DestroyRobots.SpecificTick
                     Vector2Int.zero, _ => new TestingAlgorithm((tick, _) => tracker.UpdateLogic(tick, spawner))),
                 faultInjection: new DestroyRobotsAtSpecificTickFaultInjection(RandomSeed, robotsToDestroyAtTicks));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
         }

--- a/Assets/Tests/PlayModeTests/MaterialCommunicationTest.cs
+++ b/Assets/Tests/PlayModeTests/MaterialCommunicationTest.cs
@@ -102,15 +102,17 @@ namespace Tests.PlayModeTests
 
         private void InitSimulator(MapFactory mapFactory,
             List<Vector2Int> robotSpawnPositions,
-                Dictionary<uint, Dictionary<TileType, float>> attenuationDictionary = null,
+            Dictionary<uint, Dictionary<TileType, float>> attenuationDictionary = null,
             RobotConstraints.SignalTransmissionSuccessCalculator transmissionSuccessCalculatorFunc = null
-            )
+        )
         {
             _robotTestAlgorithms = new List<TestingAlgorithm>();
             var testingScenario = new MySimulationScenario(RandomSeed,
                 mapSpawner: mapFactory,
                 hasFinishedSim: _ => false,
-                robotConstraints: new RobotConstraints(materialCommunication: true, calculateSignalTransmissionProbability: transmissionSuccessCalculatorFunc, attenuationDictionary: attenuationDictionary, slamRayTraceRange: 0, mapKnown: true),
+                robotConstraints: new RobotConstraints(materialCommunication: true,
+                    calculateSignalTransmissionProbability: transmissionSuccessCalculatorFunc,
+                    attenuationDictionary: attenuationDictionary, slamRayTraceRange: 0, mapKnown: true),
                 robotSpawner: (map, spawner) => spawner.SpawnRobotsAtPositions(robotSpawnPositions, map, RandomSeed, 2,
                     _ =>
                     {
@@ -119,8 +121,8 @@ namespace Tests.PlayModeTests
                         return algorithm;
                     }));
 
-            _maes = new MySimulator();
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
+
             _explorationSimulation = _maes.SimulationManager.CurrentSimulation;
 
             // The first robot will broadcast immediately

--- a/Assets/Tests/PlayModeTests/Robot2DControllerTest.cs
+++ b/Assets/Tests/PlayModeTests/Robot2DControllerTest.cs
@@ -74,8 +74,7 @@ namespace Tests.PlayModeTests
                         return algorithm;
                     }));
 
-            _maes = new MySimulator(false);
-            _maes.EnqueueScenario(testingScenario);
+            _maes = new MySimulator(new[] { testingScenario });
             _simulationBase = _maes.SimulationManager.CurrentSimulation ?? throw new InvalidOperationException("CurrentSimulation is null");
             _robot = _simulationBase.Robots[0];
             _maes.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,9 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SimulationScene.unity
-    guid: 78cdb79f491e7d81882669e5d666c300
-  - enabled: 1
     path: Assets/Scenes/ConscientiousReactive.unity
     guid: 048df7e9a4998eb4985bdb8d16f8b512
   m_configObjects:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1920
-  defaultScreenHeight: 1080
+  defaultScreenWidth: 800
+  defaultScreenHeight: 600
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0

--- a/run-scripts/run-headless.sh
+++ b/run-scripts/run-headless.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+limit=$1  # or set this from user input or arguments
+
+for ((i=0; i<limit; i++)); do
+    "$SCRIPT_DIR"/*.x86_64 -logFile /dev/stdout -batchmode -nographics --instances "$limit" --instanceid "$i" &
+done
+
+wait  # wait for all background processes to complete

--- a/run-scripts/run.sh
+++ b/run-scripts/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+limit=$1  # or set this from user input or arguments
+
+for ((i=0; i<limit; i++)); do
+    "$SCRIPT_DIR"/*.x86_64 -logFile /dev/stdout --instances "$limit" --instanceid "$i" &
+done
+
+wait  # wait for all background processes to complete


### PR DESCRIPTION
When building the run.sh and run-headless.sh scripts allow the user to run multiple instances of unity at once, each taking a part of the workload.

This is useful when we have many scenarios as this allows us to "multithread" the simulations.

Run the scripts by `run{,-headless}.sh <instances>`.

Also allow to build and run for Linux server target.