### PR TITLE
Save waypoint statistics in subfolder

### DIFF
--- a/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
+++ b/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
@@ -73,10 +73,10 @@ namespace Maes.Simulation.Patrolling
             var patrollingFilename = Path.Join(StatisticsFolderPath, "patrolling");
             new PatrollingCsvDataWriter(this, patrollingFilename).CreateCsvFile();
 
+            var waypointFolderPath = Path.Join(StatisticsFolderPath, "waypoints/");
+            Directory.CreateDirectory(waypointFolderPath);
             foreach (var (point, snapShots) in PatrollingTracker.WaypointSnapShots)
             {
-                var waypointFolderPath = Path.Join(StatisticsFolderPath, "waypoints/");
-                Directory.CreateDirectory(waypointFolderPath);
                 var waypointFilename = Path.Join(waypointFolderPath, $"waypoint_{point.x}_{point.y}");
                 new CsvDataWriter<WaypointSnapShot>(snapShots, waypointFilename).CreateCsvFileNoPrepare();
             }

--- a/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
+++ b/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
@@ -75,7 +75,9 @@ namespace Maes.Simulation.Patrolling
 
             foreach (var (point, snapShots) in PatrollingTracker.WaypointSnapShots)
             {
-                var waypointFilename = Path.Join(StatisticsFolderPath, $"waypoint_{point.x}_{point.y}");
+                var waypointFolderPath = Path.Join(StatisticsFolderPath, "waypoints/");
+                Directory.CreateDirectory(waypointFolderPath);
+                var waypointFilename = Path.Join(waypointFolderPath, $"waypoint_{point.x}_{point.y}");
                 new CsvDataWriter<WaypointSnapShot>(snapShots, waypointFilename).CreateCsvFileNoPrepare();
             }
             // Todo: Save Graph


### PR DESCRIPTION
If there are 99 waypoints, there would be 99 statistics files. This would make it hard to find the config dump and the combined result file.
![image](https://github.com/user-attachments/assets/f435b77b-b9dc-4935-9b6f-880b88111ef9)
Multiple scenarios in one experiment:
![image](https://github.com/user-attachments/assets/05ea9771-f24d-400d-af9c-643f5c532adf)

