### PR TITLE
Important fix to HMPAlgorithm

### DIFF
--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/MeetingPointTimePartitionGenerator.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/MeetingPoints/MeetingPointTimePartitionGenerator.cs
@@ -113,8 +113,7 @@ namespace Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints
             var meetingPointsByPartitionId = new Dictionary<int, List<MeetingPoint>>();
             foreach (var (vertexId, meetingRobotIds) in meetingRobotIdsByVertexId)
             {
-                var atTicks = tickColorAssignment[vertexId] * globalMeetingIntervalTicks;
-                var meetingPoint = new MeetingPoint(vertexId, atTicks, startMeetingAfterTicks + atTicks, meetingRobotIds);
+                var meetingPoint = new MeetingPoint(vertexId, globalMeetingIntervalTicks, startMeetingAfterTicks + globalMeetingIntervalTicks * tickColorAssignment[vertexId], meetingRobotIds);
                 foreach (var robotId in meetingRobotIds)
                 {
                     if (!meetingPointsByPartitionId.TryGetValue(robotId, out var meetingPoints))

--- a/Assets/Tests/EditModeTests/MeetingPointsWithTimeTest.cs
+++ b/Assets/Tests/EditModeTests/MeetingPointsWithTimeTest.cs
@@ -91,8 +91,10 @@ namespace Tests.EditModeTests
             var generator = new MeetingPointTimePartitionGenerator(new TestPartitionGenerator(vertexPositionsByPartitionId));
             var estimationTravel = new TravelEstimator(coarseMap, robotConstraints);
 
+            const int tickToFartestPartition = 48;
+
             generator.SetMaps(patrollingMap, coarseMap);
-            generator.SetEstimates((s, e) => estimationTravel.EstimateTime(s, e), _ => 0);
+            generator.SetEstimates((s, e) => estimationTravel.EstimateTime(s, e), _ => tickToFartestPartition);
 
             var estimateTicks = estimationTravel.EstimateTime(vertices[2].Position, vertices[4].Position)!.Value;
             var expectedGlobalTimeToNextMeeting = 2 * 3 * estimateTicks;
@@ -107,8 +109,10 @@ namespace Tests.EditModeTests
 
             //Check that the meeting point is at the correct time
             Assert.AreNotEqual(0, expectedGlobalTimeToNextMeeting);
-            Assert.AreEqual(expectedGlobalTimeToNextMeeting * 1, partitions[2].MeetingPoints[0].MeetingAtEveryTick);
-            Assert.AreEqual(expectedGlobalTimeToNextMeeting * 2, partitions[2].MeetingPoints[1].MeetingAtEveryTick);
+            Assert.AreEqual(expectedGlobalTimeToNextMeeting, partitions[2].MeetingPoints[0].MeetingAtEveryTick);
+            Assert.AreEqual(expectedGlobalTimeToNextMeeting * 1 + tickToFartestPartition, partitions[2].MeetingPoints[0].InitialMeetingAtTick);
+            Assert.AreEqual(expectedGlobalTimeToNextMeeting, partitions[2].MeetingPoints[1].MeetingAtEveryTick);
+            Assert.AreEqual(expectedGlobalTimeToNextMeeting * 2 + tickToFartestPartition, partitions[2].MeetingPoints[1].InitialMeetingAtTick);
         }
     }
 }


### PR DESCRIPTION
After making the pseudocode, there is a mistake in the HMPAlgorithm.
The first meeting that is created with time information works correct. But then the rest created meetings' time are wrong.
For example the second created meeting is meet every 2 * globalIntervalMeetingTick, but it should just be globalIntervalMeetingTick.
For example the third created meeting is meet every 3 * globalIntervalMeetingTick, but it should just be globalIntervalMeetingTick.
