### PR TITLE
Fix run-scripts

### DIFF
--- a/Assets/Editor/CopyScript.cs
+++ b/Assets/Editor/CopyScript.cs
@@ -12,17 +12,28 @@ namespace Editor
         private const string RunScriptName = "run.sh";
         private const string RunHeadlessScriptName = "run-headless.sh";
 
+        private const string ExecutableNamePlaceholder = "@EXECUTABLE_NAME";
+
         public void OnPostprocessBuild(BuildReport report)
         {
-            var projectPath = Directory.GetParent(Application.dataPath)!.ToString();
+            var dataPath = Application.dataPath;
+            var projectPath = Directory.GetParent(dataPath)!.ToString();
 
             var outputDir = Directory.GetParent(report.summary.outputPath)!.ToString();
+            var executableName = Path.GetFileName(report.summary.outputPath);
 
             var runScriptPath = Path.Join(projectPath, "run-scripts", RunScriptName);
             var runHeadlessScriptPath = Path.Join(projectPath, "run-scripts", RunHeadlessScriptName);
 
-            File.Copy(runScriptPath, Path.Join(outputDir, RunScriptName), true);
-            File.Copy(runHeadlessScriptPath, Path.Join(outputDir, RunHeadlessScriptName), true);
+            var runScriptFileContent = File.ReadAllText(runScriptPath);
+            var runHeadlessScriptFileContent = File.ReadAllText(runHeadlessScriptPath);
+
+            runScriptFileContent = runScriptFileContent.Replace(ExecutableNamePlaceholder, executableName);
+            runHeadlessScriptFileContent =
+                runHeadlessScriptFileContent.Replace(ExecutableNamePlaceholder, executableName);
+
+            File.WriteAllText(Path.Join(outputDir, RunScriptName), runScriptFileContent);
+            File.WriteAllText(Path.Join(outputDir, RunHeadlessScriptName), runHeadlessScriptFileContent);
         }
 
         public int callbackOrder { get; }

--- a/run-scripts/run-headless.sh
+++ b/run-scripts/run-headless.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 limit=$2  # or set this from user input or arguments
 
 for ((i=0; i<limit; i++)); do
-    "$SCRIPT_DIR"/*.x86_64 -logFile /dev/stdout -batchmode -nographics --instances "$limit" --instanceid "$i" --experiment "$1" &
+    "$SCRIPT_DIR/@EXECUTABLE_NAME" -logFile /dev/stdout -batchmode -nographics --instances "$limit" --instanceid "$i" --experiment "$1" &
 done
 
 wait  # wait for all background processes to complete

--- a/run-scripts/run.sh
+++ b/run-scripts/run.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 limit=$2  # or set this from user input or arguments
 
 for ((i=0; i<limit; i++)); do
-    "$SCRIPT_DIR"/*.x86_64 -logFile /dev/stdout --instances "$limit" --instanceid "$i" --experiment "$1" &
+    "$SCRIPT_DIR/@EXECUTABLE_NAME" -logFile /dev/stdout --instances "$limit" --instanceid "$i" --experiment "$1" &
 done
 
 wait  # wait for all background processes to complete


### PR DESCRIPTION
Now they are templated so they get the executable name from the build report. This fixes an issue where the exectuable was not found.