### PR TITLE
Draft improved LOS algo

### DIFF
--- a/Assets/Scripts/Utilities/Files/SaveMapAsImage.cs
+++ b/Assets/Scripts/Utilities/Files/SaveMapAsImage.cs
@@ -6,7 +6,7 @@ namespace Maes.Utilities.Files
 {
     public static class SaveAsImage
     {
-        public static void SaveVisibleTiles(HashSet<Vector2Int> pointsOfInterest, Vector2Int startPoint, bool optimized, Bitmap map)
+        public static void SaveVisibleTiles(Vector2Int startPoint, bool optimized, Bitmap map, HashSet<Vector2Int> pointsOfInterest = null)
         {
             var texture = new Texture2D(map.Width, map.Height);
             for (var x = 0; x < map.Width; x++)
@@ -19,15 +19,17 @@ namespace Maes.Utilities.Files
                     }
                     else
                     {
-
                         texture.SetPixel(x, y, Color.white);
                     }
                 }
             }
 
-            foreach (var point in pointsOfInterest)
+            if (pointsOfInterest != null)
             {
-                texture.SetPixel(point.x, point.y, Color.black);
+                foreach (var point in pointsOfInterest)
+                {
+                    texture.SetPixel(point.x, point.y, Color.black);
+                }
             }
 
             texture.SetPixel(startPoint.x, startPoint.y, Color.red);

--- a/Assets/Tests/EditModeTests/Benchmarks/LineOfSightBenchmarks.cs
+++ b/Assets/Tests/EditModeTests/Benchmarks/LineOfSightBenchmarks.cs
@@ -42,6 +42,8 @@ namespace Tests.EditModeTests.Benchmarks
             Assert.Greater(result!.Count, 0);
         }
 
+        // Make benchmark for the visibility computation of the improved algorithm
+
         private const string Map = "" +
             "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;" +
             "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;" +

--- a/Assets/Tests/EditModeTests/ComputeVisibilityTest.cs
+++ b/Assets/Tests/EditModeTests/ComputeVisibilityTest.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 
 using Maes.Map.Generators.Patrolling.Waypoints.Generators;
 using Maes.Utilities;
+using Maes.Utilities.Files;
 
 using NUnit.Framework;
 
@@ -316,5 +317,27 @@ namespace Tests.EditModeTests
             }
         }
 
+        [Test]
+        [Explicit]
+        public void EnsureEqualWaypointsTest()
+        {
+            using (var bitmap = BitmapUtilities.BitmapFromString(Map))
+            {
+                var visibility = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap);
+                var visibilityImprovement = GreedyMostVisibilityWaypointGenerator.ComputeVisibility_Improved(bitmap);
+
+                foreach (var (tile, expectedVisibility) in visibility)
+                {
+                    Assert.True(visibilityImprovement.ContainsKey(tile), "Waypoint is missing in second method at {0}!", tile);
+                    var actual = visibilityImprovement[tile];
+                    if (tile.x == 2 && tile.y == 2)
+                    {
+                        SaveAsImage.SaveVisibleTiles(tile, false, expectedVisibility);
+                        SaveAsImage.SaveVisibleTiles(tile, true, actual);
+                    }
+                    Assert.AreEqual(expectedVisibility, actual, "Waypoint does not have the same visibility at {0}!", tile);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Attempt at #409.
I implemented two ideas.
### Rim-algo
Idea:
Just do what we do now, but only calculate LOS from a point to the outer rim of the map, since we then go through "all" other tiles to get to them, and add them to the visibility map.
Finding:
Actually there are a few tiles where the angle isn't quite right. So the former approach finds more tiles than the rim-approach. Although it's much faster.

### Quadrant-algo
From a point, explore each quadrant by going from the start tile in directions (1,1), (1,-1), (-1,1) and (-1,-1). This does find all non-wall-tiles which we might have LOS on:
![image](https://github.com/user-attachments/assets/ac52318d-922a-44f0-933a-0cd9fb9c03e8)
Then the LOS algo is used on these tiles, to prune the ones we don't have LOS on. I'd say it finds the right tiles.
Finding:
The current algo finds more tiles, due to it sometimes using a special angle from some tile further away. Currently it's "slower", due to it not using multi-threading. I suspect that for big maps, like 300x300+ it might actually be faster than the current algorithm, due to it's pruning technique.


I have an idea for a third algorithm.
### Circle/angle-based algorithm
Make a line straight up/north, then go until it goes out of the map or hits a wall. Then take the point in the wall that would give the biggest clockwise angle. Then slightly increment it, and calculate which tiles this line intersects, until it hits a wall. Then repeat until the angle is 360.