### PR TITLE
AStar: Penalize tiles close to walls

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -45,7 +45,7 @@ namespace Maes.Algorithms.Patrolling.Components
         private const float MinDistance = 0.25f;
 
         // How small the angle to the target has to be before it is pointing in the direction.
-        private const float MinAngle = 1.5f;
+        private const float MinAngle = 0.5f;
 
         private readonly NextVertexDelegate _nextVertexDelegate;
         private readonly PatrollingAlgorithm _patrollingAlgorithm;
@@ -165,7 +165,19 @@ namespace Maes.Algorithms.Patrolling.Components
                     yield break;
                 }
 
-                yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, shouldContinue: false);
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+
+                // Do our own collision recovery when colliding with walls
+                if (_controller.Status != RobotStatus.Idle && !_controller.IsCurrentlyColliding)
+                {
+                    continue;
+                }
+
+                if (_controller.IsCurrentlyColliding)
+                {
+                    _controller.StopCurrentTask();
+                    yield return ComponentWaitForCondition.WaitForRobotStatus(RobotStatus.Idle, false);
+                }
 
                 var relativePosition = GetRelativePositionTo(target);
                 if (relativePosition.Distance <= MinDistance)

--- a/Assets/Scripts/Map/PatrollingMap.cs
+++ b/Assets/Scripts/Map/PatrollingMap.cs
@@ -70,11 +70,6 @@ namespace Maes.Map
 
         private static IReadOnlyDictionary<(int, int), IReadOnlyList<PathStep>> CreatePaths(IReadOnlyList<Vertex> vertices, SimulationMap<Tile> simulationMap)
         {
-            // TODO: Skip this if we can use the breath first search stuff from WatchmanRouteSolver.
-            // TODO: Of cause this requires specific code for that waypoint generation algorithm.
-
-            var startTime = Time.realtimeSinceStartup;
-
             // HACK: Creating a slam map with robot constraints seems a bit hacky tbh :(
             var slamMap = new SlamMap(simulationMap, new RobotConstraints(mapKnown: true), 0);
             var coarseMap = slamMap.CoarseMap;


### PR DESCRIPTION
This makes it less likely that robots collide with walls.

Add simple collision recovery in GoToNextVertexComponent. If the robot is colliding rotate and move the robot to the target. Collision recovery can still be delegated to another more advanced component, but this works well for wall collision recovery.