### PR TITLE
Robots always selected vertex 0 at simulation start

### DIFF
--- a/Assets/Scripts/Utilities/PatrollingVerticesExtension.cs
+++ b/Assets/Scripts/Utilities/PatrollingVerticesExtension.cs
@@ -41,7 +41,7 @@ namespace Maes.Utilities
 
             foreach (var vertex in vertices.AsSpan(1))
             {
-                var distance = estimateToTarget(closestVertex.Position);
+                var distance = estimateToTarget(vertex.Position);
                 if (distance.CompareTo(closestDistance) >= 0)
                 {
                     continue;


### PR DESCRIPTION
 - Robots now correctly select the initial vertex
