### PR TITLE
Fix aborting task mechanism

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/GoToNextVertexComponent.cs
@@ -117,7 +117,11 @@ namespace Maes.Algorithms.Patrolling.Components
 
                 if (_abortingTask != null)
                 {
-                    ApproachingVertex = _abortingTask.Value.TargetVertex;
+                    while (GetRelativePositionTo(ApproachingVertex.Position).Distance > MinDistance)
+                    {
+                        _controller.PathAndMoveTo(ApproachingVertex.Position, dependOnBrokenBehaviour: false);
+                        yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+                    }
                     _abortingTask = null;
                 }
 
@@ -217,6 +221,7 @@ namespace Maes.Algorithms.Patrolling.Components
         {
             _abortingTask = abortingTask;
             TargetPosition = abortingTask.TargetVertex.Position;
+            ApproachingVertex = abortingTask.TargetVertex;
         }
     }
 }


### PR DESCRIPTION
This PR ensures that if AbortCurrentTask is called, then afterwards it moves to the vertex specified in the AbortCurrentTask. This mechanism was previously handled by another component, but may not be enabled in all cases. Therefore the check in GoToNextComponent on line 120, ensure that is goes to the vertex specified the aborting task.