### PR TITLE
NewAStar: Implement broken behaviour and partial paths

### DIFF
--- a/Assets/Scripts/Map/PathFinding/MyAStar.cs
+++ b/Assets/Scripts/Map/PathFinding/MyAStar.cs
@@ -77,7 +77,7 @@ namespace Maes.Map.PathFinding
             TMap pathFindingMap, bool beOptimistic = false, bool acceptPartialPaths = false)
         where TMap : IPathFindingMap
         {
-            var path = NewAStar.FindPath(startCoordinate, targetCoordinate, pathFindingMap, beOptimistic);
+            var path = NewAStar.FindPath(startCoordinate, targetCoordinate, pathFindingMap, beOptimistic, dependOnBrokenBehaviour: false);
             return path?.ToArray();
         }
 
@@ -97,6 +97,11 @@ namespace Maes.Map.PathFinding
             if (!pathFindingMap.BrokenCollisionMap)
             {
                 return GetNonBrokenPath(startCoordinate, targetCoordinate, pathFindingMap, beOptimistic: beOptimistic, acceptPartialPaths: acceptPartialPaths);
+            }
+
+            if (!acceptPartialPaths)
+            {
+                return NewAStar.FindPath(startCoordinate, targetCoordinate, pathFindingMap, beOptimistic, dependOnBrokenBehaviour: true)?.ToArray();
             }
 
             while (true)

--- a/Assets/Scripts/Map/PathFinding/NewAStar.cs
+++ b/Assets/Scripts/Map/PathFinding/NewAStar.cs
@@ -42,7 +42,18 @@ namespace Maes.Map.PathFinding
         private static readonly Vector2Int TopLeft = new Vector2Int(-1, 1);
 
         // TODO: Support partial paths
-        public static List<Vector2Int>? FindPath<TMap>(Vector2Int start, Vector2Int goal, TMap map, bool beOptimistic)
+
+        /// <summary>
+        /// Find a path from <paramref name="start"/> to <paramref name="goal"/>.
+        /// </summary>
+        /// <param name="start">The coordinate to start from.</param>
+        /// <param name="goal">The coordinate to find a path to.</param>
+        /// <param name="map">The map to pathfind on.</param>
+        /// <param name="beOptimistic">Whether or not to treat unseen tiles as walkable.</param>
+        /// <param name="dependOnBrokenBehaviour">The goal might be in a wall, allow pathing to it anyway.</param>
+        /// <typeparam name="TMap">The type of <paramref name="map"/>.</typeparam>
+        /// <returns>The path or <see langword="null"/> if no path was found.</returns>
+        public static List<Vector2Int>? FindPath<TMap>(Vector2Int start, Vector2Int goal, TMap map, bool beOptimistic, bool dependOnBrokenBehaviour)
             where TMap : IPathFindingMap
         {
             Func<Vector2Int, bool> isSolid = beOptimistic ? map.IsOptimisticSolid : map.IsSolid;
@@ -91,42 +102,42 @@ namespace Maes.Map.PathFinding
                 var anyNeighboringWalls =
                     wallTop || wallTopRight || wallRight || wallBottomRight || wallBottom || wallBottomLeft || wallLeft || wallTopLeft;
 
-                if (!wallTop)
+                if (!wallTop || (dependOnBrokenBehaviour && top == goal))
                 {
                     ProcessNeighbor(current, top, currentParent, false, anyNeighboringWalls);
                 }
 
-                if (!wallTopRight && !wallTop && !wallRight)
+                if ((!wallTopRight || (dependOnBrokenBehaviour && topRight == goal)) && !wallTop && !wallRight)
                 {
                     ProcessNeighbor(current, topRight, currentParent, true, anyNeighboringWalls);
                 }
 
-                if (!wallRight)
+                if (!wallRight || (dependOnBrokenBehaviour && right == goal))
                 {
                     ProcessNeighbor(current, right, currentParent, false, anyNeighboringWalls);
                 }
 
-                if (!wallBottomRight && !wallRight && !wallBottom)
+                if ((!wallBottomRight || (dependOnBrokenBehaviour && bottomRight == goal)) && !wallRight && !wallBottom)
                 {
                     ProcessNeighbor(current, bottomRight, currentParent, true, anyNeighboringWalls);
                 }
 
-                if (!wallBottom)
+                if (!wallBottom || (dependOnBrokenBehaviour && bottom == goal))
                 {
                     ProcessNeighbor(current, bottom, currentParent, false, anyNeighboringWalls);
                 }
 
-                if (!wallBottomLeft && !wallBottom && !wallLeft)
+                if ((!wallBottomLeft || (dependOnBrokenBehaviour && bottomLeft == goal)) && !wallBottom && !wallLeft)
                 {
                     ProcessNeighbor(current, bottomLeft, currentParent, true, anyNeighboringWalls);
                 }
 
-                if (!wallLeft)
+                if (!wallLeft || (dependOnBrokenBehaviour && left == goal))
                 {
                     ProcessNeighbor(current, left, currentParent, false, anyNeighboringWalls);
                 }
 
-                if (!wallTopLeft && !wallTop && !wallLeft)
+                if ((!wallTopLeft || (dependOnBrokenBehaviour && topLeft == goal)) && !wallTop && !wallLeft)
                 {
                     ProcessNeighbor(current, topLeft, currentParent, true, anyNeighboringWalls);
                 }

--- a/Assets/Scripts/Map/PatrollingMap.cs
+++ b/Assets/Scripts/Map/PatrollingMap.cs
@@ -87,7 +87,7 @@ namespace Maes.Map
             {
                 foreach (var neighbor in vertex.Neighbors)
                 {
-                    var path = aStar.GetNonBrokenPath(vertex.Position, neighbor.Position, coarseMap) ?? throw new InvalidOperationException("No path from vertex to neighbor");
+                    var path = MyAStar.GetNonBrokenPath(vertex.Position, neighbor.Position, coarseMap) ?? throw new InvalidOperationException("No path from vertex to neighbor");
                     var pathSteps = MyAStar.PathToStepsCheap(path);
 
                     paths.Add((vertex.Id, neighbor.Id), pathSteps);


### PR DESCRIPTION
NewAStar: Add depend on broken behaviour

When the collision map is broken it says there is a wall where there isnt. To account for this if the goal is one tile into a wall, allow the robot to move into it.


NewAstar: Implement partial paths

A partial path just paths to the closest coordinate to the target if a direct path cannot be found due to unseen tiles.