### PR TITLE
Cache waypoint generator

### DIFF
--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/GreedyMostVisibilityWaypointGenerator.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/GreedyMostVisibilityWaypointGenerator.cs
@@ -55,6 +55,18 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Generators
         /// <returns></returns>
         public static HashSet<Vector2Int> VertexPositionsFromMap(Bitmap map, float maxDistance = 0f)
         {
+            return WaypointGeneratorCache<GreedyMostVisibilityWaypointGeneratorCacheKey>.Cached(
+                map,
+                () => VertexPositionsFromMapComputation(map, maxDistance),
+                hash =>
+                {
+                    hash.Append(maxDistance);
+                    return hash;
+                });
+        }
+
+        private static HashSet<Vector2Int> VertexPositionsFromMapComputation(Bitmap map, float maxDistance)
+        {
             var precomputedVisibility = ComputeVisibility(map, maxDistance);
             return ComputeVertexCoordinates(map, precomputedVisibility);
         }
@@ -195,5 +207,7 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Generators
 
             return precomputedVisibilities;
         }
+
+        private sealed class GreedyMostVisibilityWaypointGeneratorCacheKey { }
     }
 }

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/WaypointGeneratorCache.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/WaypointGeneratorCache.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+using Maes.Utilities;
+
+using UnityEngine;
+
+namespace Maes.Map.Generators.Patrolling.Waypoints.Generators
+{
+    public static class WaypointGeneratorCache<TWaypointGenerator>
+    {
+        // Collisions may happen but the chance is so low we can ignore it.
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly Dictionary<Hash128, HashSet<Vector2Int>> Cache = new();
+
+        /// <summary>
+        /// Retrieve from or compute and add to the cache.
+        /// </summary>
+        /// <param name="bitmap">The map use to generate waypoints.</param>
+        /// <param name="computationFunction">The function used to compute the waypoints if it isn't in the cache.</param>
+        /// <param name="extraHash">Extra hashing, useful for parameters to the generator.</param>
+        /// <returns>The cached or computed waypoints.</returns>
+        public static HashSet<Vector2Int> Cached(Bitmap bitmap, Func<HashSet<Vector2Int>> computationFunction, Func<Hash128, Hash128>? extraHash = null)
+        {
+            extraHash ??= IdentityHash;
+
+            var hash = extraHash(bitmap.Hash());
+
+            if (Cache.TryGetValue(hash, out var cachedWaypoints))
+            {
+                // We have a cache hit!
+                // Return a copy
+                return new HashSet<Vector2Int>(cachedWaypoints);
+            }
+
+            // We don't have a hit.
+            // Do the expensive computation and add it to the cache.
+            var waypoints = computationFunction();
+            Cache.Add(hash, new HashSet<Vector2Int>(waypoints));
+            return waypoints;
+        }
+
+        private static Hash128 IdentityHash(Hash128 hash)
+        {
+            return hash;
+        }
+    }
+}

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/WaypointGeneratorCache.cs.meta
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Generators/WaypointGeneratorCache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d6b571e8af184237be8a31023bb26dd8
+timeCreated: 1747636181

--- a/Assets/Scripts/Utilities/Bitmap.cs
+++ b/Assets/Scripts/Utilities/Bitmap.cs
@@ -404,6 +404,16 @@ namespace Maes.Utilities
             }
         }
 
+        public Hash128 Hash()
+        {
+            var hash = new Hash128();
+            hash.Append(Width);
+            hash.Append(Height);
+            hash.Append(_bits, 0, _length);
+
+            return hash;
+        }
+
         /// <summary>
         /// Enumerates a Bitmap returning a <see cref="Vector2Int"/> for each bit set.
         /// </summary>


### PR DESCRIPTION
We currently only have one waypoint generator, but this caching mechanism can be used for any waypoint generator.

It only stores the hash of the bitmap (and extra data), and a hashset of vertex positions.
This means that we can basically store infinitely many things in our cache, as it uses almost no memory.
Furthermore, as the cache is entirely in memory, no issues with old invalid caches will happen.