### PR TITLE
Add experiment to find optimal ratio of robot count / map size

### DIFF
--- a/Assets/Scenes/GroupAExperimentScenes/GroupAMapSizetoRobotCountRatioExperiment.unity
+++ b/Assets/Scenes/GroupAExperimentScenes/GroupAMapSizetoRobotCountRatioExperiment.unity
@@ -1,0 +1,170 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1154502373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1154502375}
+  - component: {fileID: 1154502374}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1154502374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154502373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13de83607a968231299434a5a73623f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1154502375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154502373}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1154502375}

--- a/Assets/Scenes/GroupAExperimentScenes/GroupAMapSizetoRobotCountRatioExperiment.unity.meta
+++ b/Assets/Scenes/GroupAExperimentScenes/GroupAMapSizetoRobotCountRatioExperiment.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2d8f45b0880332e0ab86e5c717ed87fd
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeExperiment.cs
@@ -44,11 +44,11 @@ namespace Maes.Experiments.Patrolling
             var scenarios = new List<MySimulationScenario>();
             foreach (var seed in GroupAParameters.SeedGenerator())
             {
-                foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
+                foreach (var mapSize in _mapSizes)
                 {
-                    var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
-                    foreach (var mapSize in _mapSizes)
+                    foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
                     {
+                        var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
                         scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, GroupAParameters.StandardRobotCount, mapSize));
                     }
                 }

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs
@@ -1,0 +1,69 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: 
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+
+using System.Collections.Generic;
+
+using Maes.Simulation.Patrolling;
+using Maes.UI;
+
+using UnityEngine;
+
+namespace Maes.Experiments.Patrolling
+{
+    using MySimulationScenario = PatrollingSimulationScenario;
+    using MySimulator = PatrollingSimulator;
+
+    /// <summary>
+    /// AAU group cs-25-ds-10-17
+    /// </summary>
+    internal class GroupAMapSizeToRobotCountRatioExperiment : MonoBehaviour
+    {
+        private static readonly List<int> _mapSizes = new() { 100, 150, 200, 250, 300 };
+        private static readonly List<int> _robotCounts = new() { 1, 2, 4, 8, 16 };
+
+        private void Start()
+        {
+            var scenarios = new List<MySimulationScenario>();
+            foreach (var seed in GroupAParameters.SeedGenerator())
+            {
+                foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
+                {
+                    var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
+                    foreach (var mapSize in _mapSizes)
+                    {
+                        foreach (var robotCount in _robotCounts)
+                        {
+                            scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, robotCount, mapSize));
+                        }
+                    }
+                }
+            }
+
+            Debug.Log($"Total scenarios scheduled: {scenarios.Count}");
+
+            var simulator = new MySimulator(scenarios);
+
+            simulator.PressPlayButton(); // Instantly enter play mode
+            simulator.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+        }
+    }
+}

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs
@@ -45,11 +45,11 @@ namespace Maes.Experiments.Patrolling
             var scenarios = new List<MySimulationScenario>();
             foreach (var seed in GroupAParameters.SeedGenerator())
             {
-                foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
+                foreach (var mapSize in _mapSizes)
                 {
-                    var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
-                    foreach (var mapSize in _mapSizes)
+                    foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
                     {
+                        var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
                         foreach (var robotCount in _robotCounts)
                         {
                             scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, robotCount, mapSize));

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs.meta
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioExperiment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13de83607a968231299434a5a73623f1


### PR DESCRIPTION
- Experiment to find the optimal ratio of robot count / map size.
- Move mapsize to be the second outer-most foreach, such that the sequential distribution of scenarios on cloud instances has better chances of being of same mapsize, which give more cache-hits for the waypoint generation