### PR TITLE
Add scenario name to error log

### DIFF
--- a/Assets/Scenes/DebugScenarioFailureExperiment.unity
+++ b/Assets/Scenes/DebugScenarioFailureExperiment.unity
@@ -1,0 +1,170 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &396293611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 396293613}
+  - component: {fileID: 396293612}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &396293612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396293611}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5af1640e909d2cd5bfd9dfee3c5df55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &396293613
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396293611}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 396293613}

--- a/Assets/Scenes/DebugScenarioFailureExperiment.unity.meta
+++ b/Assets/Scenes/DebugScenarioFailureExperiment.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0ab060b5756141597af1914fade3a70e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs
@@ -1,0 +1,63 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+// 
+// Contributors: 
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+
+using System.Collections.Generic;
+
+using Maes.Simulation.Patrolling;
+using Maes.UI;
+
+using UnityEngine;
+
+namespace Maes.Experiments.Patrolling
+{
+    using MySimulationScenario = PatrollingSimulationScenario;
+    using MySimulator = PatrollingSimulator;
+
+    /// <summary>
+    /// AAU group cs-25-ds-10-17
+    /// This fails every third scenario.
+    /// This way both building and cave maps are tested.
+    /// </summary>
+    internal class DebugScenarioFailureExperiment : MonoBehaviour
+    {
+        private void Start()
+        {
+            var scenarioCounter = 0;
+            var scenarios = new List<MySimulationScenario>();
+            foreach (var seed in GroupAParameters.SeedGenerator(1))
+            {
+                foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
+                {
+                    var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
+                    scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, GroupAParameters.StandardRobotCount, 100, shouldFail: scenarioCounter++ % 3 == 0));
+                }
+            }
+
+            Debug.Log($"Total scenarios scheduled: {scenarios.Count}");
+
+            var simulator = new MySimulator(scenarios);
+
+            simulator.PressPlayButton(); // Instantly enter play mode
+            simulator.SimulationManager.AttemptSetPlayState(SimulationPlayState.FastAsPossible);
+        }
+    }
+}

--- a/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs
@@ -48,7 +48,7 @@ namespace Maes.Experiments.Patrolling
                 foreach (var (algorithmName, lambda) in GroupAParameters.StandardAlgorithms)
                 {
                     var (patrollingMapFactory, algorithm) = lambda(GroupAParameters.StandardRobotCount);
-                    scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, GroupAParameters.StandardRobotCount, 100, shouldFail: scenarioCounter++ % 3 == 0));
+                    scenarios.AddRange(GroupAExperimentHelpers.CreateScenarios(seed, algorithmName, algorithm, patrollingMapFactory, 4, 100, shouldFail: scenarioCounter++ % 3 == 0));
                 }
             }
 

--- a/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs.meta
+++ b/Assets/Scripts/Experiments/Patrolling/DebugScenarioFailureExperiment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5af1640e909d2cd5bfd9dfee3c5df55

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAExperimentHelpers.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAExperimentHelpers.cs
@@ -78,8 +78,8 @@ namespace Maes.Experiments.Patrolling
             var scenarios = new List<MySimulationScenario>();
             var buildingMapConfig = new BuildingMapConfig(seed, widthInTiles: mapSize, heightInTiles: mapSize, brokenCollisionMap: false);
             var caveMapConfig = new CaveMapConfig(seed, widthInTiles: mapSize, heightInTiles: mapSize, brokenCollisionMap: false);
-            var scenarioBuilding = ScenarioConstructor(seed, algorithmName, algorithm, patrollingMapFactory, buildingMapConfig, robotCount, GroupAParameters.CreateRobotConstraints(communicationDistanceThroughWalls));
-            var scenarioCave = ScenarioConstructor(seed, algorithmName, algorithm, patrollingMapFactory, caveMapConfig, robotCount, GroupAParameters.CreateRobotConstraints(communicationDistanceThroughWalls));
+            var scenarioBuilding = ScenarioConstructor(seed, algorithmName, algorithm, patrollingMapFactory, buildingMapConfig, robotCount, GroupAParameters.CreateRobotConstraints(communicationDistanceThroughWalls), shouldFail);
+            var scenarioCave = ScenarioConstructor(seed, algorithmName, algorithm, patrollingMapFactory, caveMapConfig, robotCount, GroupAParameters.CreateRobotConstraints(communicationDistanceThroughWalls), shouldFail);
             scenarios.Add(scenarioBuilding);
             scenarios.Add(scenarioCave);
             return scenarios;

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAExperimentHelpers.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAExperimentHelpers.cs
@@ -35,7 +35,7 @@ namespace Maes.Experiments.Patrolling
 
     internal static class GroupAExperimentHelpers
     {
-        public static MySimulationScenario ScenarioConstructor(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, BuildingMapConfig mapConfig, int robotCount, RobotConstraints robotConstraints)
+        public static MySimulationScenario ScenarioConstructor(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, BuildingMapConfig mapConfig, int robotCount, RobotConstraints robotConstraints, bool shouldFail = false)
         {
             return new MySimulationScenario(
                                         seed: seed,
@@ -51,10 +51,10 @@ namespace Maes.Experiments.Patrolling
                                         statisticsFileName:
                                         $"{algorithmName}-seed-{seed}-size-{mapConfig.HeightInTiles}-robots-{robotCount}-constraints-{GroupAParameters.StandardRobotConstraintName}-BuildingMap-SpawnApart",
                                         patrollingMapFactory: patrollingMapFactory,
-                                        maxLogicTicks: GroupAParameters.StandardAmountOfCycles * MySimulationScenario.DefaultMaxLogicTicks);
+                                        maxLogicTicks: shouldFail ? 0 : GroupAParameters.StandardAmountOfCycles * MySimulationScenario.DefaultMaxLogicTicks);
         }
 
-        public static MySimulationScenario ScenarioConstructor(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, CaveMapConfig mapConfig, int robotCount, RobotConstraints robotConstraints)
+        public static MySimulationScenario ScenarioConstructor(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, CaveMapConfig mapConfig, int robotCount, RobotConstraints robotConstraints, bool shouldFail = false)
         {
             return new MySimulationScenario(
                                        seed: seed,
@@ -70,10 +70,10 @@ namespace Maes.Experiments.Patrolling
                                        statisticsFileName:
                                        $"{algorithmName}-seed-{seed}-size-{mapConfig.HeightInTiles}-robots-{robotCount}-constraints-{GroupAParameters.StandardRobotConstraintName}-CaveMap-SpawnApart",
                                        patrollingMapFactory: patrollingMapFactory,
-                                       maxLogicTicks: GroupAParameters.StandardAmountOfCycles * MySimulationScenario.DefaultMaxLogicTicks);
+                                       maxLogicTicks: shouldFail ? 0 : GroupAParameters.StandardAmountOfCycles * MySimulationScenario.DefaultMaxLogicTicks);
         }
 
-        public static IEnumerable<MySimulationScenario> CreateScenarios(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, int robotCount = GroupAParameters.StandardRobotCount, int mapSize = GroupAParameters.StandardMapSize, float communicationDistanceThroughWalls = 0f)
+        public static IEnumerable<MySimulationScenario> CreateScenarios(int seed, string algorithmName, CreateAlgorithmDelegate algorithm, PatrollingMapFactory? patrollingMapFactory, int robotCount = GroupAParameters.StandardRobotCount, int mapSize = GroupAParameters.StandardMapSize, float communicationDistanceThroughWalls = 0f, bool shouldFail = false)
         {
             var scenarios = new List<MySimulationScenario>();
             var buildingMapConfig = new BuildingMapConfig(seed, widthInTiles: mapSize, heightInTiles: mapSize, brokenCollisionMap: false);

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAParameters.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAParameters.cs
@@ -46,9 +46,11 @@ namespace Maes.Experiments.Patrolling
             { nameof(ConscientiousReactiveAlgorithm), (_) => (null, (_) => new ConscientiousReactiveAlgorithm()) },
 
             // ConscientiousReactiveAlgorithm with partitioning
+            /*
             { nameof(ConscientiousReactiveAlgorithm)+ "+partitioning", (robotCount) => ((map) =>
                 PartitioningGenerator.MakePatrollingMapWithSpectralBisectionPartitions(map, robotCount, CreateRobotConstraints()),
                  (_) => new ConscientiousReactiveAlgorithm()) },
+                 */
     
             // The map is different for each seed, so the algorithm can just use the same seed for all maps.
             { nameof(RandomReactive), (_) => (null, (_) => new RandomReactive(1)) },

--- a/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
+++ b/Assets/Scripts/Simulation/Patrolling/PatrollingSimulation.cs
@@ -57,7 +57,7 @@ namespace Maes.Simulation.Patrolling
 
         protected override void CreateStatisticsFile()
         {
-            Debug.Log("Creating statistics file");
+            Debug.Log($"Creating statistics folder at {StatisticsFolderPath}");
             Directory.CreateDirectory(StatisticsFolderPath);
 
             var patrollingFilename = Path.Join(StatisticsFolderPath, "patrolling");

--- a/Assets/Scripts/Simulation/SimulationManager.cs
+++ b/Assets/Scripts/Simulation/SimulationManager.cs
@@ -243,7 +243,7 @@ namespace Maes.Simulation
             {
                 if (!reason!.Value.Success)
                 {
-                    Debug.LogErrorFormat("Simulation did not complete successfully: {0}", reason.Value.Message);
+                    Debug.LogErrorFormat("Simulation did not complete successfully: {0}, {1}", reason.Value.Message, CurrentScenario.StatisticsFileName);
                 }
 
                 CurrentSimulation.OnSimulationFinished(reason.Value.Success);

--- a/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
@@ -36,7 +36,6 @@ namespace Maes.Statistics.Writer
                 csv.WriteRecord(snapShot);
                 csv.NextRecord();
             }
-            Debug.Log($"Writing statistics to path: {_path}");
         }
 
         public void CreateCsvFileNoPrepare(string separator = ",")

--- a/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/Writer/CsvDataWriter.cs
@@ -5,8 +5,6 @@ using System.IO;
 using CsvHelper;
 using CsvHelper.Configuration;
 
-using UnityEngine;
-
 namespace Maes.Statistics.Writer
 {
     public class CsvDataWriter<TSnapShot>
@@ -47,8 +45,6 @@ namespace Maes.Statistics.Writer
             });
 
             csv.WriteRecords(_snapShots);
-
-            Debug.Log($"Writing statistics to path: {_path}");
         }
 
         protected virtual void PrepareSnapShot(TSnapShot snapShot) { }

--- a/run-scripts/run-headless.sh
+++ b/run-scripts/run-headless.sh
@@ -11,7 +11,6 @@ then
     exit 1
 fi
 
-
 # Get the directory where the script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -22,3 +21,10 @@ limit=$2  # or set this from user input or arguments
 done } | tee output.log
 
 wait  # wait for all background processes to complete
+
+grep "Simulation did not complete successfully" output.log > failed.log
+
+# Check if grep found any matches, print error message in red if it did
+if [ -s failed.log ]; then
+    echo -e "\e[31mSome simulations failed. Check failed.log for details.\e[0m"
+fi

--- a/run-scripts/run-headless.sh
+++ b/run-scripts/run-headless.sh
@@ -22,7 +22,11 @@ done } | tee output.log
 
 wait  # wait for all background processes to complete
 
+echo "All instances have shut down."
+
 grep "Simulation did not complete successfully" output.log > failed.log
+
+echo "Finished making output.log and failed.log"
 
 # Check if grep found any matches, print error message in red if it did
 if [ -s failed.log ]; then

--- a/run-scripts/run.sh
+++ b/run-scripts/run.sh
@@ -21,3 +21,10 @@ limit=$2  # or set this from user input or arguments
 done } | tee output.log
 
 wait  # wait for all background processes to complete
+
+grep "Simulation did not complete successfully" output.log > failed.log
+
+# Check if grep found any matches, print error message in red if it did
+if [ -s failed.log ]; then
+    echo -e "\e[31mSome simulations failed. Check failed.log for details.\e[0m"
+fi

--- a/run-scripts/run.sh
+++ b/run-scripts/run.sh
@@ -22,7 +22,11 @@ done } | tee output.log
 
 wait  # wait for all background processes to complete
 
+echo "All instances have shut down."
+
 grep "Simulation did not complete successfully" output.log > failed.log
+
+echo "Finished making output.log and failed.log"
 
 # Check if grep found any matches, print error message in red if it did
 if [ -s failed.log ]; then


### PR DESCRIPTION
#446 
This makes a file called failure.log with the names of all experiments that fail.
This outcomments CRPartitioning, since it's broken.
This removes the logging of the csv writer which logs for every waypoint csv file, which is spam.
This makes an experiment to check if the script runs successfully, which it does, I tested it.