### PR TITLE
Fix cr crashing when it has not neighbors

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/ConscientiousReactiveAlgorithm.cs
@@ -28,7 +28,8 @@ namespace Maes.Algorithms.Patrolling
 
         private static Vertex NextVertex(Vertex currentVertex)
         {
-            return currentVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
+            // If the current vertex has no neighbors, return it
+            return currentVertex.Neighbors.Count == 0 ? currentVertex : currentVertex.Neighbors.OrderBy(x => x.LastTimeVisitedTick).First();
         }
     }
 }


### PR DESCRIPTION
If you run partitioning on a too small map, then a vertex may be its own partition and not have any neighbors, the linq then throws.