### PR TITLE
CsvDataWriter: Fix file is being used error

### DIFF
--- a/Assets/Scripts/Statistics/CsvDataWriter.cs
+++ b/Assets/Scripts/Statistics/CsvDataWriter.cs
@@ -50,6 +50,7 @@ namespace Maes.Statistics
         public void Finish()
         {
             _csvWriter.Dispose();
+            _streamWriter.Dispose();
 
             // TOCTOU problem
             if (File.Exists(_path))

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -598,8 +598,8 @@ PlayerSettings:
   il2cppStacktraceInformation:
     Standalone: 1
   managedStrippingLevel:
-    Server: 1
-    Standalone: 1
+    Server: 4
+    Standalone: 4
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1
   allowUnsafeCode: 0


### PR DESCRIPTION
When calling Finish() I forgot to dispose the stream writer which probably held the file.