### PR TITLE
Immediate takeover algo

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
@@ -28,6 +28,7 @@ using Maes.Algorithms.Patrolling.Components;
 using Maes.Algorithms.Patrolling.HeuristicConscientiousReactive;
 using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover.MeetingPoints;
 using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover.TrackInfos;
+using Maes.Assets.Scripts.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover;
 using Maes.Map;
 using Maes.Map.Generators.Patrolling.Partitioning;
 using Maes.Map.Generators.Patrolling.Partitioning.MeetingPoints;

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
@@ -68,7 +68,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             RobotId = new RobotIdClass(controller.Id);
             _partitionComponent = new PartitionComponent(RobotId, GeneratePartitions);
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap, GetInitialVertexToPatrol);
-            _meetingComponent = new MeetingComponent(-200, -200, () => LogicTicks, EstimateTime, patrollingMap, Controller, _partitionComponent, ExchangeInformation, OnMissingRobotAtMeeting, _goToNextVertexComponent);
+            _meetingComponent = new MeetingComponent(-200, -200, () => LogicTicks, EstimateTime, patrollingMap, Controller, _partitionComponent, ExchangeInformation, OnMissingRobotAtMeeting, _goToNextVertexComponent, RobotId);
 
             return new IComponent[] { _partitionComponent, _meetingComponent, _goToNextVertexComponent };
         }

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
@@ -49,6 +49,8 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         {
             _heuristicConscientiousReactiveLogic = new HeuristicConscientiousReactiveLogic(DistanceMethod, seed);
         }
+
+        public RobotIdClass RobotId;
         public override string AlgorithmName => "HMPAlgorithm";
         public PartitionInfo PartitionInfo => _partitionComponent.PartitionInfo!;
         public override Dictionary<int, Color32[]> ColorsByVertexId => _partitionComponent.PartitionInfo?
@@ -63,7 +65,8 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
 
         protected override IComponent[] CreateComponents(IRobotController controller, PatrollingMap patrollingMap)
         {
-            _partitionComponent = new PartitionComponent(controller, GeneratePartitions);
+            RobotId = new RobotIdClass(controller.Id);
+            _partitionComponent = new PartitionComponent(RobotId, GeneratePartitions);
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap, GetInitialVertexToPatrol);
             _meetingComponent = new MeetingComponent(-200, -200, () => LogicTicks, EstimateTime, patrollingMap, Controller, _partitionComponent, ExchangeInformation, OnMissingRobotAtMeeting, _goToNextVertexComponent);
 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
@@ -46,9 +46,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
     /// </summary>
     public sealed class HMPPatrollingAlgorithm : PatrollingAlgorithm
     {
-        public HMPPatrollingAlgorithm(int seed = 0)
+        public HMPPatrollingAlgorithm(PartitionComponent.TakeoverStrategy takeoverStrategy, int seed = 0)
         {
             _heuristicConscientiousReactiveLogic = new HeuristicConscientiousReactiveLogic(DistanceMethod, seed);
+            _takeoverStrategy = takeoverStrategy;
         }
 
         public RobotIdClass RobotId;
@@ -59,7 +60,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
                                                                            .ToDictionary(vertexId => vertexId, _ => new[] { Controller.Color }) ?? new Dictionary<int, Color32[]>();
 
         private readonly HeuristicConscientiousReactiveLogic _heuristicConscientiousReactiveLogic;
-
+        private readonly PartitionComponent.TakeoverStrategy _takeoverStrategy;
         private PartitionComponent _partitionComponent = null!;
         private MeetingComponent _meetingComponent = null!;
         private GoToNextVertexComponent _goToNextVertexComponent = null!;
@@ -67,7 +68,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         protected override IComponent[] CreateComponents(IRobotController controller, PatrollingMap patrollingMap)
         {
             RobotId = new RobotIdClass(controller.Id);
-            _partitionComponent = new PartitionComponent(RobotId, GeneratePartitions);
+            _partitionComponent = new PartitionComponent(RobotId, GeneratePartitions, _takeoverStrategy);
             _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap, GetInitialVertexToPatrol);
             _meetingComponent = new MeetingComponent(-200, -200, () => LogicTicks, EstimateTime, patrollingMap, Controller, _partitionComponent, ExchangeInformation, OnMissingRobotAtMeeting, _goToNextVertexComponent, RobotId);
 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 using Maes.Algorithms.Patrolling.Components;
 using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover.MeetingPoints;
+using Maes.Assets.Scripts.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover;
 using Maes.Map;
 using Maes.Robot;
 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
@@ -25,7 +25,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             EstimateTimeDelegate estimateTime,
             PatrollingMap patrollingMap, IRobotController controller, PartitionComponent partitionComponent,
             ExchangeInformationAtMeetingDelegate exchangeInformation, OnMissingRobotsAtMeetingDelegate onMissingRobotsAtMeeting,
-            IMovementComponent movementComponent)
+            IMovementComponent movementComponent, RobotIdClass robotIdClass)
         {
             PreUpdateOrder = preUpdateOrder;
             PostUpdateOrder = postUpdateOrder;
@@ -35,6 +35,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             _exchangeInformation = exchangeInformation;
             _onMissingRobotsAtMeeting = onMissingRobotsAtMeeting;
             _movementComponent = movementComponent;
+            _robotIdClass = robotIdClass;
             _partitionComponent = partitionComponent;
             _patrollingMap = patrollingMap;
         }
@@ -46,6 +47,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         private readonly EstimateTimeDelegate _estimateTime;
         private readonly IRobotController _controller;
         private readonly IMovementComponent _movementComponent;
+        private readonly RobotIdClass _robotIdClass;
         private readonly NextMeetingPointDecider _nextMeetingPointDecider = new();
         private readonly ExchangeInformationAtMeetingDelegate _exchangeInformation;
         private readonly OnMissingRobotsAtMeetingDelegate _onMissingRobotsAtMeeting;
@@ -77,14 +79,14 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
                 }
 
                 var meeting = GoingToMeeting.Value;
-                var otherRobotIds = meeting.MeetingPoint.RobotIds.Where(id => id != _controller.Id).ToHashSet();
+                var otherRobotIds = meeting.MeetingPoint.RobotIds.Where(id => id != _robotIdClass.RobotId).ToHashSet();
 
                 // Wait until all other robots are at the meeting point
-                var senseNearByRobotIds = SenseNearbyRobots.GetRobotIds(_controller, meeting);
+                var senseNearByRobotIds = SenseNearbyRobots.GetRobotIds(_controller, meeting, _robotIdClass);
                 while (!senseNearByRobotIds.SetEquals(otherRobotIds) && _getLogicTick() < meeting.MeetingAtTick)
                 {
                     yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
-                    senseNearByRobotIds = SenseNearbyRobots.GetRobotIds(_controller, meeting);
+                    senseNearByRobotIds = SenseNearbyRobots.GetRobotIds(_controller, meeting, _robotIdClass);
                 }
 
                 // If all other robots are at the meeting point, then exchange information
@@ -267,9 +269,9 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             /// <param name="controller">The robot controller.</param>
             /// <param name="meeting">The meeting that the robot is going to.</param>
             /// <returns>Returns the ids of the robots that are sensed and going to the same meeting.</returns>
-            public static HashSet<int> GetRobotIds(IRobotController controller, Meeting meeting)
+            public static HashSet<int> GetRobotIds(IRobotController controller, Meeting meeting, RobotIdClass robotIdClass)
             {
-                controller.Broadcast(new GoingToMeetingMessage(meeting.MeetingPoint, meeting.MeetingAtTick, controller.Id));
+                controller.Broadcast(new GoingToMeetingMessage(meeting.MeetingPoint, meeting.MeetingAtTick, robotIdClass.RobotId));
                 var robotIds = new HashSet<int>();
                 var messages = controller.ReceiveBroadcast().OfType<GoingToMeetingMessage>();
 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/MeetingComponent.cs
@@ -39,6 +39,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             _robotIdClass = robotIdClass;
             _partitionComponent = partitionComponent;
             _patrollingMap = patrollingMap;
+            _nextMeetingPointDecider = new NextMeetingPointDecider(getLogicTick);
         }
 
         public int PreUpdateOrder { get; }
@@ -49,7 +50,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         private readonly IRobotController _controller;
         private readonly IMovementComponent _movementComponent;
         private readonly RobotIdClass _robotIdClass;
-        private readonly NextMeetingPointDecider _nextMeetingPointDecider = new();
+        private readonly NextMeetingPointDecider _nextMeetingPointDecider;
         private readonly ExchangeInformationAtMeetingDelegate _exchangeInformation;
         private readonly OnMissingRobotsAtMeetingDelegate _onMissingRobotsAtMeeting;
         private readonly PartitionComponent _partitionComponent;
@@ -224,15 +225,31 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         /// </summary>
         private class NextMeetingPointDecider
         {
+            public NextMeetingPointDecider(Func<int> getLogicTick)
+            {
+                _getLogicTick = getLogicTick;
+            }
+
+            private readonly Func<int> _getLogicTick;
             private readonly Dictionary<MeetingPoint, int> _heldMeetingsAtMeetingPoint = new();
 
             public Meeting GetNextMeeting(IReadOnlyList<MeetingPoint> meetingPoints, PatrollingMap patrollingMap)
             {
                 var bestMeetingPoint = meetingPoints[0];
                 var bestMeetingAtTick = bestMeetingPoint.GetMeetingAtTick(GetHeldMeetings(bestMeetingPoint));
+                while (bestMeetingAtTick < _getLogicTick())
+                {
+                    HeldMeeting(bestMeetingPoint);
+                    bestMeetingAtTick = bestMeetingPoint.GetMeetingAtTick(GetHeldMeetings(bestMeetingPoint));
+                }
                 foreach (var meetingPoint in meetingPoints.Skip(1))
                 {
                     var meetingAtTick = meetingPoint.GetMeetingAtTick(GetHeldMeetings(meetingPoint));
+                    while (meetingAtTick < _getLogicTick())
+                    {
+                        HeldMeeting(meetingPoint);
+                        meetingAtTick = meetingPoint.GetMeetingAtTick(GetHeldMeetings(meetingPoint));
+                    }
                     if (meetingAtTick < bestMeetingAtTick)
                     {
                         bestMeetingPoint = meetingPoint;

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Maes.Algorithms.Patrolling.Components;
+using Maes.Assets.Scripts.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover;
 using Maes.Map;
 using Maes.Robot;
 
@@ -23,7 +24,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         public int PreUpdateOrder => -900;
         public int PostUpdateOrder => -900;
 
-        private RobotIdClass _robotId;
+        private readonly RobotIdClass _robotId;
         private readonly PartitionGenerator _partitionGenerator;
 
         protected StartupComponent<IReadOnlyDictionary<int, PartitionInfo>, PartitionComponent> _startupComponent = null!;

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
@@ -86,6 +86,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             var missingRobotsSorted = missingRobots.ToList();
             missingRobotsSorted.Sort();
             var myIndex = robotsThatShowedUp.IndexOf(_robotId.RobotId);
+            Debug.Log($"Meeting at vertex: {meeting.MeetingPoint.VertexId} at tick: {meeting.MeetingAtTick} with showed up count: {robotsThatShowedUp.Count}; {string.Join(' ', robotsThatShowedUp)} and missing robot count: {missingRobotsSorted.Count}; {string.Join(' ', missingRobotsSorted)} missing robots.");
             if (myIndex < missingRobotsSorted.Count)
             {
                 // Pick the id of one of the missing robots to take over

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
@@ -85,8 +85,16 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             robotsThatShowedUp.Sort();
             var missingRobotsSorted = missingRobots.ToList();
             missingRobotsSorted.Sort();
-            var myIndex = robotsThatShowedUp.IndexOf(_robotId.RobotId);
             Debug.Log($"Meeting at vertex: {meeting.MeetingPoint.VertexId} at tick: {meeting.MeetingAtTick} with showed up count: {robotsThatShowedUp.Count}; {string.Join(' ', robotsThatShowedUp)} and missing robot count: {missingRobotsSorted.Count}; {string.Join(' ', missingRobotsSorted)} missing robots.");
+
+            ImmediateTakeover(robotsThatShowedUp, missingRobotsSorted);
+
+            yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+        }
+
+        private void ImmediateTakeover(List<int> robotsThatShowedUp, List<int> missingRobotsSorted)
+        {
+            var myIndex = robotsThatShowedUp.IndexOf(_robotId.RobotId);
             if (myIndex < missingRobotsSorted.Count)
             {
                 // Pick the id of one of the missing robots to take over
@@ -98,8 +106,6 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
                 }
                 TakeOverOtherRobotPartition(robotIdToTakeOver);
             }
-
-            yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
         }
 
         private void TakeOverOtherRobotPartition(int robotId)

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
@@ -14,16 +14,16 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
     {
         public delegate Dictionary<int, PartitionInfo> PartitionGenerator(HashSet<int> robots);
 
-        public PartitionComponent(IRobotController controller, PartitionGenerator partitionGenerator)
+        public PartitionComponent(RobotIdClass robotId, PartitionGenerator partitionGenerator)
         {
-            _robotId = controller.Id;
+            _robotId = robotId;
             _partitionGenerator = partitionGenerator;
         }
 
         public int PreUpdateOrder => -900;
         public int PostUpdateOrder => -900;
 
-        private int _robotId;
+        private RobotIdClass _robotId;
         private readonly PartitionGenerator _partitionGenerator;
 
         protected StartupComponent<IReadOnlyDictionary<int, PartitionInfo>, PartitionComponent> _startupComponent = null!;
@@ -60,7 +60,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
 
             while (true)
             {
-                var success = _virtualStigmergyComponent.TryGet(_robotId, out var partitionInfo);
+                var success = _virtualStigmergyComponent.TryGet(_robotId.RobotId, out var partitionInfo);
                 Debug.Assert(success);
                 PartitionInfo = partitionInfo!;
                 yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
@@ -83,7 +83,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             Debug.Log("Some robots are not at the meeting point");
             // Pick the id of one of the missing robots at random
             var missingRobotId = missingRobots.ToList()[Random.Range(0, missingRobots.Count)];
-            _robotId = missingRobotId;
+            _robotId.RobotId = missingRobotId;
+            _virtualStigmergyComponent.TryGet(_robotId.RobotId, out var partitionInfo);
+            Debug.Assert(partitionInfo != null, "PartitionInfo should not be null");
+            PartitionInfo = partitionInfo!;
 
             yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
         }

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/PartitionComponent.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 using Maes.Algorithms.Patrolling.Components;
 using Maes.Map;
@@ -22,7 +23,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         public int PreUpdateOrder => -900;
         public int PostUpdateOrder => -900;
 
-        private readonly int _robotId;
+        private int _robotId;
         private readonly PartitionGenerator _partitionGenerator;
 
         protected StartupComponent<IReadOnlyDictionary<int, PartitionInfo>, PartitionComponent> _startupComponent = null!;
@@ -80,6 +81,9 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
         {
             // TODO: Implement the logic for when some other robots are not at the meeting point
             Debug.Log("Some robots are not at the meeting point");
+            // Pick the id of one of the missing robots at random
+            var missingRobotId = missingRobots.ToList()[Random.Range(0, missingRobots.Count)];
+            _robotId = missingRobotId;
 
             yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
         }

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/RobotIdClass.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/RobotIdClass.cs
@@ -1,0 +1,13 @@
+
+namespace Maes.Assets.Scripts.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
+{
+    public sealed class RobotIdClass
+    {
+        public RobotIdClass(int robotId)
+        {
+            RobotId = robotId;
+        }
+
+        public int RobotId { get; set; }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/RobotIdClass.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/RobotIdClass.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 644eabcdd5ad973609da33e0660d0540

--- a/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingImmediateTakeoverExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingImmediateTakeoverExperiment.cs
@@ -22,10 +22,12 @@
 
 using System.Collections.Generic;
 
+using Maes.Algorithms.Patrolling;
 using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover;
 using Maes.Map.Generators;
 using Maes.Map.Generators.Patrolling.Waypoints.Generators;
 using Maes.Robot;
+using Maes.Simulation;
 using Maes.Simulation.Patrolling;
 
 using UnityEngine;
@@ -60,7 +62,7 @@ namespace Maes.Experiments.Patrolling
             scenarios.Add(
                 new MySimulationScenario(
                     seed: seed,
-                    totalCycles: 4,
+                    totalCycles: 100,
                     stopAfterDiff: false,
                     robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                         collisionMap: buildingConfig,
@@ -71,7 +73,8 @@ namespace Maes.Experiments.Patrolling
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints,
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
-                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
+                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap,
+                    maxLogicTicks: SimulationScenario<PatrollingSimulation, IPatrollingAlgorithm>.DefaultMaxLogicTicks * 100)
             );
 
             var simulator = new MySimulator(scenarios);

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingImmediateTakeoverTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingImmediateTakeoverTest.cs
@@ -1,0 +1,226 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+//
+// Contributors 2025: 
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+
+using System.Collections;
+using System.Collections.Generic;
+
+using Maes.Algorithms;
+using Maes.Algorithms.Patrolling;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover;
+using Maes.Map;
+using Maes.Map.Generators;
+using Maes.Map.Generators.Patrolling.Waypoints.Generators;
+using Maes.Robot;
+using Maes.Simulation.Patrolling;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
+{
+    public class HmpPatrollingImmediateTakeoverTest
+    {
+        private PatrollingSimulator _maes;
+        private const int Seed = 1;
+        private const int MaxSimulatedLogicTicks = 250000;
+        private const int MapSize = 50;
+        private const int RobotCount = 2;
+        private const int TotalCycles = 3;
+        private TrackerVertices _trackerVertices;
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _maes.Destroy();
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator Test_RobotsPatrolOnlyItsPartition()
+        {
+            _trackerVertices = new TrackerVertices();
+            CreateAndEnqueueScenario();
+
+            var simulation = _maes.SimulationManager.CurrentSimulation!;
+
+            _maes.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
+            while (!_trackerVertices.CheckIsRobotPatrollingOwnPartition() && !simulation.HasFinishedSim() && simulation.SimulatedLogicTicks < MaxSimulatedLogicTicks)
+            {
+                yield return null;
+            }
+
+            Assert.IsTrue(_trackerVertices.IsRobotPatrollingOwnPartition, "Robots are not patrolling their own partition or not visited all its vertices.");
+        }
+
+        private void CreateAndEnqueueScenario()
+        {
+
+            var robotConstraints = new RobotConstraints(
+                mapKnown: true,
+                distributeSlam: false,
+                slamRayTraceRange: 0f,
+                robotCollisions: false,
+                calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls == 0f);
+
+            var mapConfig = new BuildingMapConfig(123, widthInTiles: MapSize, heightInTiles: MapSize, brokenCollisionMap: false);
+
+            var scenarios = new[] {(
+                new PatrollingSimulationScenario(
+                    seed: Seed,
+                    totalCycles: TotalCycles,
+                    stopAfterDiff: false,
+                    robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
+                        collisionMap: buildingConfig,
+                        seed: Seed,
+                        numberOfRobots: RobotCount,
+                        suggestedStartingPoint: null,
+                        createAlgorithmDelegate: _ => new WrapperHMPPatrollingAlgorithm(_trackerVertices)),
+                    mapSpawner: generator => generator.GenerateMap(mapConfig),
+                    robotConstraints: robotConstraints,
+                    statisticsFileName: $"test",
+                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
+            )};
+
+            _maes = new PatrollingSimulator(scenarios);
+        }
+
+        private class TrackerVertices
+        {
+            private readonly Dictionary<int, HashSet<int>> _observedRobotVertices = new();
+            private readonly Dictionary<int, HashSet<int>> _generatedRobotVertices = new();
+
+            public void AddRobot(int robotId, HMPPatrollingAlgorithm algorithm)
+            {
+                _observedRobotVertices[robotId] = new HashSet<int>();
+                algorithm.SubscribeOnReachVertex(vertexId =>
+                {
+                    _observedRobotVertices[robotId].Add(vertexId);
+                });
+            }
+
+            public void AddGeneratedRobotVertices(HMPPatrollingAlgorithm algorithm)
+            {
+                var partitionInfo = algorithm.PartitionInfo;
+                if (partitionInfo is { VertexIds: { Count: > 0 } })
+                {
+                    _generatedRobotVertices[partitionInfo.RobotId] = new HashSet<int>(partitionInfo.VertexIds);
+                }
+            }
+
+            public bool IsRobotPatrollingOwnPartition { get; private set; }
+
+            public bool CheckIsRobotPatrollingOwnPartition()
+            {
+                if (_generatedRobotVertices.Count == 0)
+                {
+                    IsRobotPatrollingOwnPartition = false;
+                    return IsRobotPatrollingOwnPartition;
+                }
+
+                foreach (var (robotId, expected) in _generatedRobotVertices)
+                {
+                    if (!_observedRobotVertices[robotId].SetEquals(expected))
+                    {
+                        IsRobotPatrollingOwnPartition = false;
+                        return IsRobotPatrollingOwnPartition;
+                    }
+                }
+
+                IsRobotPatrollingOwnPartition = true;
+                return IsRobotPatrollingOwnPartition;
+            }
+        }
+
+        private class WrapperHMPPatrollingAlgorithm : IPatrollingAlgorithm
+        {
+            public WrapperHMPPatrollingAlgorithm(TrackerVertices trackerVertices)
+            {
+                _algorithm = new HMPPatrollingAlgorithm();
+                _trackerVertices = trackerVertices;
+            }
+
+            private readonly HMPPatrollingAlgorithm _algorithm;
+            private readonly TrackerVertices _trackerVertices;
+
+            public string AlgorithmName => _algorithm.AlgorithmName;
+            public Vertex TargetVertex => _algorithm.TargetVertex;
+            public Dictionary<int, Color32[]> ColorsByVertexId => _algorithm.ColorsByVertexId;
+
+            public int LogicTicks => throw new System.NotImplementedException();
+
+            public void SetPatrollingMap(PatrollingMap map)
+            {
+                _algorithm.SetPatrollingMap(map);
+            }
+
+            public void SetGlobalPatrollingMap(PatrollingMap globalMap)
+            {
+                _algorithm.SetGlobalPatrollingMap(globalMap);
+            }
+
+            public void SubscribeOnReachVertex(OnReachVertex onReachVertex)
+            {
+                _algorithm.SubscribeOnReachVertex(onReachVertex);
+            }
+
+            public void SubscribeOnTrackInfo(OnTrackInfo onTrackInfo)
+            {
+
+            }
+
+            public IEnumerable<WaitForCondition> PreUpdateLogic()
+            {
+                foreach (var result in _algorithm.PreUpdateLogic())
+                {
+                    _trackerVertices.AddGeneratedRobotVertices(_algorithm);
+                    yield return result;
+                }
+            }
+
+            public IEnumerable<WaitForCondition> UpdateLogic()
+            {
+                return _algorithm.UpdateLogic();
+            }
+
+            public void SetController(Robot2DController controller)
+            {
+                _algorithm.SetController(controller);
+                _trackerVertices.AddRobot(controller.Id, _algorithm);
+            }
+
+            public string GetDebugInfo()
+            {
+                return _algorithm.GetDebugInfo();
+            }
+
+            public bool HasSeenAllInPartition(int assignedPartition)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void ResetSeenVerticesForPartition(int partitionId)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingImmediateTakeoverTest.cs.meta
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingImmediateTakeoverTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fe2a2ba604418bc2a963b3013b78c05

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingQuasiRandomTakeoverTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingQuasiRandomTakeoverTest.cs
@@ -38,7 +38,7 @@ using UnityEngine;
 
 namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
 {
-    public class HmpPatrollingImmediateTakeoverTest
+    public class HmpPatrollingQuasiRandomTakeoverTest
     {
         private PatrollingSimulator _maes;
         private const int Seed = 1;
@@ -93,7 +93,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
                         seed: Seed,
                         numberOfRobots: RobotCount,
                         suggestedStartingPoint: null,
-                        createAlgorithmDelegate: _ => new WrapperHMPPatrollingAlgorithm(_trackerVertices, PartitionComponent.TakeoverStrategy.ImmediateTakeoverStrategy)),
+                        createAlgorithmDelegate: _ => new WrapperHMPPatrollingAlgorithm(_trackerVertices, PartitionComponent.TakeoverStrategy.QuasiRandomStrategy)),
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints,
                     statisticsFileName: $"test",

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingQuasiRandomTakeoverTest.cs.meta
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HmpPatrollingQuasiRandomTakeoverTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d551ba8389eae4fdbb826a4557b423e2


### PR DESCRIPTION
This algo is HMPPatrolling, but where it doesn't warn neighbors before taking over a dead robots partition. It takes over by taking the robot id of the missing robot, it does not patrol two partitions at the same time. It constantly switches.