### PR TITLE
Hmp v2 fault

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/Components/VirtualStigmergyComponent.cs
@@ -277,6 +277,11 @@ namespace Maes.Algorithms.Patrolling.Components
             return ret;
         }
 
+        public IEnumerable<KeyValuePair<TKey, ValueInfo>> GetLocalKnowledge()
+        {
+            return _localKnowledge;
+        }
+
         /// <summary>
         /// Checks if a key exists in the local knowledge
         /// </summary>
@@ -308,6 +313,7 @@ namespace Maes.Algorithms.Patrolling.Components
             if (_localKnowledge.Count > 0)
             {
                 stringBuilder.Append("Local Knowledge:\n");
+                stringBuilder.Append("  \"key\": (timestamp, robotId, \"Value\"),\n");
                 foreach (var (key, valueInfo) in _localKnowledge)
                 {
                     stringBuilder.AppendFormat("  \"{0}\": ({1}, {2}, \"{3}\"),\n", key, valueInfo.Timestamp, valueInfo.RobotId, valueInfo.Value);

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
@@ -176,11 +176,11 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 
 
             var bestMeeting = meetingTimes[0];
-            
+
             var skippingMeetingTimes = meetingTimes.Skip(1).Where(m => m.Item1.MeetingAtTick == bestMeeting.Item1.MeetingAtTick)
                 .Select(m => m.Item3)
                 .ToArray();
-            
+
 
             if (meetingTimes.Length > 1)
             {

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
@@ -175,16 +175,21 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
                 .ToArray();
 
 
+
             var bestMeeting = meetingTimes[0];
 
             var skippingMeetingTimes = meetingTimes.Skip(1).Where(m => m.Item1.MeetingAtTick == bestMeeting.Item1.MeetingAtTick)
                 .Select(m => m.Item3)
                 .ToArray();
 
-
-            if (meetingTimes.Length > 1)
+            if (skippingMeetingTimes.Length > 1)
             {
-                _partitionComponent.SkipingMeetingTimesWithSameTime(skippingMeetingTimes);
+                Debug.Log($"tick {bestMeeting.Item1.MeetingAtTick} and robot {_controller.Id}: skippingMeetingTimes are {string.Join(",\n", skippingMeetingTimes.Select(m => m.vertexId))}");
+            }
+
+            if (skippingMeetingTimes.Length > 1)
+            {
+                _partitionComponent.SkippingMeetingTimesWithSameTime(skippingMeetingTimes);
             }
 
             return bestMeeting.Item1;

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/MeetingComponent.cs
@@ -88,7 +88,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 
                     if (unknownRobotIds.Count > 0)
                     {
-                        foreach (var waitForCondition in _partitionComponent.OnMeetingAnotherRobotAtMeeting(meeting.Vertex.Id))
+                        foreach (var waitForCondition in _partitionComponent.OnMeetingAnotherRobotAtMeeting(meeting.Vertex.Id, readyRobotIds, unknownRobotIds))
                         {
                             yield return waitForCondition;
                         }
@@ -96,7 +96,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
                     else
                     {
                         var missingRobotIds = meeting.RobotIds.Except(readyRobotIds).ToHashSet();
-                        _trackInfo(new MissingRobotsAtMeetingTrackInfo(meeting, missingRobotIds, _controller.Id));
+                        _trackInfo(new MissingRobotsAtMeetingTrackInfo(meeting, meeting.MeetingAtTick, _controller.Id, missingRobotIds, _controller.Id));
                         foreach (var waitForCondition in _partitionComponent.OnMissingRobotAtMeeting(meeting, missingRobotIds.Single()))
                         {
                             yield return waitForCondition;

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/PartitionComponent.cs
@@ -4,11 +4,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Maes.Algorithms.Patrolling.Components;
-using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.MeetingPoints;
 using Maes.Map;
 using Maes.Robot;
 
 using UnityEngine;
+
 
 namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 {
@@ -16,18 +16,36 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
     {
         public readonly struct MeetingTimes
         {
+            public readonly IReadOnlyCollection<int> RobotIds;
             public readonly int CurrentNextMeetingAtTick;
             public readonly int NextNextMeetingAtTick;
+            public readonly bool MightMissCurrentNextMeetingAtTick;
 
-            public MeetingTimes(int currentNextMeetingAtTick, int nextNextMeetingAtTick)
+            public MeetingTimes(int currentNextMeetingAtTick, int nextNextMeetingAtTick, IReadOnlyCollection<int> robotIds, bool mightMissCurrentNextMeetingAtTick = false)
             {
                 CurrentNextMeetingAtTick = currentNextMeetingAtTick;
                 NextNextMeetingAtTick = nextNextMeetingAtTick;
+                RobotIds = robotIds;
+                MightMissCurrentNextMeetingAtTick = mightMissCurrentNextMeetingAtTick;
             }
 
             public override string ToString()
             {
-                return $"({CurrentNextMeetingAtTick}, {NextNextMeetingAtTick})";
+                return $"({CurrentNextMeetingAtTick}, {NextNextMeetingAtTick}, ({string.Join(", ", RobotIds)})), {MightMissCurrentNextMeetingAtTick})";
+            }
+        }
+
+        public readonly struct MissingRobot
+        {
+            public readonly int RobotId;
+            public readonly int AtVertexId;
+            public readonly int MissingAtTick;
+
+            public MissingRobot(int robotId, int vertexId, int missingAtTick)
+            {
+                RobotId = robotId;
+                AtVertexId = vertexId;
+                MissingAtTick = missingAtTick;
             }
         }
 
@@ -42,8 +60,6 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 
         public int PreUpdateOrder => -900;
         public int PostUpdateOrder => -900;
-
-        public IReadOnlyDictionary<int, MeetingPoint> MeetingPointsByVertexId { get; private set; } = null!;
 
         public IEnumerable<int> VerticesByIdToPatrol
         {
@@ -66,12 +82,18 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
             }
         }
 
+        private int? _skipPartitionId;
         public IEnumerable<(int vertexId, MeetingTimes meetingTimes)> MeetingPoints
         {
             get
             {
                 for (var i = 0; i < _partitions.Length; i++)
                 {
+                    if (_skipPartitionId == i)
+                    {
+                        continue;
+                    }
+
                     var success =
                         _partitionIdToRobotIdVirtualStigmergyComponent.TryGetNonSending(i, out var assignedRobot);
                     Debug.Assert(success);
@@ -107,6 +129,8 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
         private VirtualStigmergyComponent<int, MeetingTimes, PartitionComponent>
             _meetingPointVertexIdToMeetingTimesStigmergyComponent = null!;
 
+        private VirtualStigmergyComponent<int, MissingRobot, PartitionComponent> _missingMeetingByVertexIdStigmergyComponent =
+            null!;
 
 
         public IComponent[] CreateComponents(IRobotController controller, PatrollingMap patrollingMap)
@@ -115,6 +139,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 
             _partitionIdToRobotIdVirtualStigmergyComponent = new(OnPartitionConflict, controller);
             _meetingPointVertexIdToMeetingTimesStigmergyComponent = new(OnMeetingConflict, controller);
+            _missingMeetingByVertexIdStigmergyComponent = new VirtualStigmergyComponent<int, MissingRobot, PartitionComponent>(OnMissingRobotConflict, controller);
 
             return new IComponent[] { _startupComponent, _partitionIdToRobotIdVirtualStigmergyComponent, _meetingPointVertexIdToMeetingTimesStigmergyComponent };
         }
@@ -122,7 +147,6 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
         [SuppressMessage("ReSharper", "IteratorNeverReturns")]
         public IEnumerable<ComponentWaitForCondition> PreUpdateLogic()
         {
-            var meetingPointsByVertexId = new Dictionary<int, MeetingPoint>();
             var partitions = _startupComponent.Message;
 
             _partitions = new PartitionInfo[partitions.Count];
@@ -138,14 +162,11 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
                 // Set up meeting points
                 foreach (var meetingPoint in partition.MeetingPoints)
                 {
-                    meetingPointsByVertexId[meetingPoint.VertexId] = meetingPoint;
-                    _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meetingPoint.VertexId, new MeetingTimes(meetingPoint.InitialCurrentNextMeetingAtTick, meetingPoint.InitialNextNextMeetingAtTick));
+                    _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meetingPoint.VertexId, new MeetingTimes(meetingPoint.InitialCurrentNextMeetingAtTick, meetingPoint.InitialNextNextMeetingAtTick, meetingPoint.RobotIds));
                 }
 
                 partitionId++;
             }
-
-            MeetingPointsByVertexId = meetingPointsByVertexId;
 
             while (true)
             {
@@ -153,16 +174,143 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
             }
         }
 
+        /*public class MeetingHandler
+        {
+            public int MeetingPointVertexId { get; set; }
+            public MeetingTimes MeetingTimes { get; set; }
+            private readonly IRobotController _robotController;
+            private int RobotId => _robotController.Id;
+            private readonly MissingRobot? _missingRobot;
+            private readonly Func<ITrackInfo> _trackInfoFunc;
+            private readonly PartitionInfo[] _partitions;
+
+            private readonly VirtualStigmergyComponent<int, int, PartitionComponent> _partitionIdToRobotIdVirtualStigmergyComponent;
+            private readonly VirtualStigmergyComponent<int, MeetingTimes, PartitionComponent> _meetingPointVertexIdToMeetingTimesStigmergyComponent;
+            private readonly VirtualStigmergyComponent<int, MissingRobot, PartitionComponent> _missingMeetingByVertexIdStigmergyComponent;
+
+            public MeetingHandler(IRobotController robotController, int meetingPointVertexId, Func<ITrackInfo> trackInfoFunc, 
+                VirtualStigmergyComponent<int, int, PartitionComponent> partitionIdToRobotIdVirtualStigmergyComponent, 
+                VirtualStigmergyComponent<int, MeetingTimes, PartitionComponent> meetingPointVertexIdToMeetingTimesStigmergyComponent, 
+                VirtualStigmergyComponent<int, MissingRobot, PartitionComponent> missingMeetingByVertexIdStigmergyComponent,
+                IReadOnlyDictionary<int, MeetingPoint> meetingPointsByVertexId, PartitionInfo[] partitions, MissingRobot? missingRobot = null)
+            {
+                _robotController = robotController;
+                MeetingPointVertexId = meetingPointVertexId;
+                _missingRobot = missingRobot;
+                _trackInfoFunc = trackInfoFunc;
+                _partitionIdToRobotIdVirtualStigmergyComponent = partitionIdToRobotIdVirtualStigmergyComponent;
+                _meetingPointVertexIdToMeetingTimesStigmergyComponent = meetingPointVertexIdToMeetingTimesStigmergyComponent;
+                _missingMeetingByVertexIdStigmergyComponent = missingMeetingByVertexIdStigmergyComponent;
+                _partitions = partitions;
+            }
+
+            public IEnumerable<ComponentWaitForCondition> HandleMeeting()
+            {
+                var nextPossibleMeetingTime = NextPossibleMeetingTime();
+                _robotController.Broadcast(new MeetingMessage(RobotId, nextPossibleMeetingTime, _missingRobot is null));
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+
+                var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>().ToArray();
+                var nextMeetingTime = Math.Max(meetingMessages.Select(m => m.ProposedNextNextMeetingAtTick).Max(), nextPossibleMeetingTime);
+                var mightMissCurrentNextMeetingAtTick = meetingMessages.Any(m => m.MightMissCurrentNextMeetingAtTick);
+                Debug.Assert(MeetingTimes.RobotIds.Count - 1 == meetingMessages.Count());
+
+                var success = _meetingPointVertexIdToMeetingTimesStigmergyComponent.TryGetNonSending(MeetingPointVertexId,
+                    out var meetingTimes);
+                Debug.Assert(success);
+
+                Debug.LogFormat("Decided that the next meeting time for vertex {0} should be {1}", MeetingPointVertexId, nextMeetingTime);
+
+                _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(MeetingPointVertexId, new MeetingTimes(meetingTimes.NextNextMeetingAtTick, nextMeetingTime, MeetingTimes.RobotIds, mightMissCurrentNextMeetingAtTick));
+                _meetingPointVertexIdToMeetingTimesStigmergyComponent.SendAll();
+
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+            }
+            
+            public IEnumerable<ComponentWaitForCondition> OnMissingRobotAtMeeting(int meetingPointVertexId, MeetingComponent.Meeting meeting, int missingRobotId)
+            {
+                if (_missingRobot is not null)
+                {
+                    var partitionIdsByRobotId = _partitionIdToRobotIdVirtualStigmergyComponent.GetLocalKnowledge()
+                        .GroupBy(kvp => kvp.Value.Value, kvp => kvp.Key)
+                        .ToDictionary(grouping => grouping.Key, grouping => grouping.AsEnumerable());
+
+                    _skipPartitionId = partitionIdsByRobotId[_robotId].First();
+
+                    var takeOverPartitionIds = meeting.RobotIds.SelectMany(robotId => partitionIdsByRobotId[robotId]);
+
+                    foreach (var partitionId in takeOverPartitionIds)
+                    {
+                        _partitionIdToRobotIdVirtualStigmergyComponent.Put(partitionId, _robotId);
+                    }
+                }
+                else
+                {
+                    _missingRobot = new MissingRobot(missingRobotId, meetingPointVertexId, meeting.MeetingAtTick);
+                    _missingMeetingByVertexIdStigmergyComponent.Put(meeting.Vertex.Id, _missingRobot!.Value);
+                }
+                
+                
+                var nextPossibleMeetingTime = NextPossibleMeetingTime();
+                _robotController.Broadcast(new MeetingMessage(_robotId, nextPossibleMeetingTime));
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+
+                var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>().ToArray();
+                var nextMeetingTime = Math.Max(meetingMessages.Select(m => m.ProposedNextNextMeetingAtTick).Max(), nextPossibleMeetingTime);
+                
+                var success = _meetingPointVertexIdToMeetingTimesStigmergyComponent.TryGetNonSending(meetingPointVertexId,
+                    out var meetingTimes);
+                Debug.Assert(success);
+
+                _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meetingPointVertexId, new MeetingTimes(meetingTimes.NextNextMeetingAtTick, nextMeetingTime, meetingTimes.RobotId));
+                
+                _meetingPointVertexIdToMeetingTimesStigmergyComponent.SendAll();
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+            }
+
+            
+            
+            private int NextPossibleMeetingTime()
+            {
+                var interval = 0;
+                var highestNextNextMeetingAtTicks = 0;
+                for (var i = 0; i < _partitions.Length; i++)
+                {
+                    var success =
+                        _partitionIdToRobotIdVirtualStigmergyComponent.TryGetNonSending(i, out var assignedRobotId);
+                    Debug.Assert(success);
+
+                    if (assignedRobotId == RobotId)
+                    {
+                        interval += _partitions[i].Diameter;
+                        var partitionsHighestNextNextMeetingAtTicks = _partitions[i].MeetingPoints.Select(m =>
+                        {
+                            var success =
+                                _meetingPointVertexIdToMeetingTimesStigmergyComponent.TryGetNonSending(m.VertexId,
+                                    out var meetingTimes);
+                            Debug.Assert(success);
+                            return meetingTimes.NextNextMeetingAtTick;
+                        }).Max();
+                        highestNextNextMeetingAtTicks = Math.Max(highestNextNextMeetingAtTicks,
+                            partitionsHighestNextNextMeetingAtTicks);
+                    }
+                }
+
+                return interval + highestNextNextMeetingAtTicks;
+            }
+        }*/
+
+
+
         public IEnumerable<ComponentWaitForCondition> ExchangeInformation(int meetingPointVertexId)
         {
             var nextPossibleMeetingTime = NextPossibleMeetingTime();
-            _robotController.Broadcast(new MeetingMessage(_robotId, nextPossibleMeetingTime));
+            _robotController.Broadcast(new MeetingMessage(_robotId, nextPossibleMeetingTime, _missingRobot is null));
             yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
 
-            var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>();
+            var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>().ToArray();
             var nextMeetingTime = Math.Max(meetingMessages.Select(m => m.ProposedNextNextMeetingAtTick).Max(), nextPossibleMeetingTime);
-
-            Debug.Assert(MeetingPointsByVertexId[meetingPointVertexId].RobotIds.Count - 1 == meetingMessages.Count());
+            var mightMissCurrentNextMeetingAtTick = meetingMessages.Any(m => m.MightMissCurrentNextMeetingAtTick);
 
             var success = _meetingPointVertexIdToMeetingTimesStigmergyComponent.TryGetNonSending(meetingPointVertexId,
                 out var meetingTimes);
@@ -170,19 +318,70 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
 
             Debug.LogFormat("Decided that the next meeting time for vertex {0} should be {1}", meetingPointVertexId, nextMeetingTime);
 
-            _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meetingPointVertexId, new MeetingTimes(meetingTimes.NextNextMeetingAtTick, nextMeetingTime));
+            _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meetingPointVertexId, new MeetingTimes(meetingTimes.NextNextMeetingAtTick, nextMeetingTime, meetingTimes.RobotIds, mightMissCurrentNextMeetingAtTick));
             _meetingPointVertexIdToMeetingTimesStigmergyComponent.SendAll();
+            _partitionIdToRobotIdVirtualStigmergyComponent.SendAll();
+            _missingMeetingByVertexIdStigmergyComponent.SendAll();
 
             yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
         }
 
-        public IEnumerable<ComponentWaitForCondition> OnMissingRobotAtMeeting(MeetingComponent.Meeting meeting, HashSet<int> missingRobots)
+        private MissingRobot? _missingRobot;
+        public IEnumerable<ComponentWaitForCondition> OnMissingRobotAtMeeting(MeetingComponent.Meeting meeting, int missingRobotId)
         {
-            // TODO: Implement the logic for when some other robots are not at the meeting point
-            Debug.Log("Some robots are not at the meeting point");
+            if (_missingRobot?.AtVertexId == meeting.Vertex.Id)
+            {
+                var partitionIdsByRobotId = _partitionIdToRobotIdVirtualStigmergyComponent.GetLocalKnowledge()
+                    .GroupBy(kvp => kvp.Value.Value, kvp => kvp.Key)
+                    .ToDictionary(grouping => grouping.Key, grouping => grouping.AsEnumerable());
 
+                _skipPartitionId = partitionIdsByRobotId[_robotId].First();
+
+                var takeOverPartitionIds = meeting.RobotIds.SelectMany(robotId => partitionIdsByRobotId[robotId]);
+
+                foreach (var partitionId in takeOverPartitionIds)
+                {
+                    _partitionIdToRobotIdVirtualStigmergyComponent.Put(partitionId, _robotId);
+                }
+                _missingRobot = null;
+            }
+            else if (_missingRobot is null)
+            {
+                _missingRobot = new MissingRobot(missingRobotId, meeting.Vertex.Id, meeting.MeetingAtTick);
+                _missingMeetingByVertexIdStigmergyComponent.Put(meeting.Vertex.Id, _missingRobot!.Value);
+            }
+            else
+            {
+                Debug.Assert(false, "We should not have a missing robot here, Only one missing robot should be allowed at a time.");
+            }
+
+
+            var nextPossibleMeetingTime = NextPossibleMeetingTime();
+            _robotController.Broadcast(new MeetingMessage(_robotId, nextPossibleMeetingTime));
+            yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+
+            var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>().ToArray();
+            var nextMeetingTime = Math.Max(meetingMessages.Select(m => m.ProposedNextNextMeetingAtTick).Max(), nextPossibleMeetingTime);
+
+            var success = _meetingPointVertexIdToMeetingTimesStigmergyComponent.TryGetNonSending(meeting.Vertex.Id,
+                out var meetingTimes);
+            Debug.Assert(success);
+
+            _meetingPointVertexIdToMeetingTimesStigmergyComponent.Put(meeting.Vertex.Id, new MeetingTimes(meetingTimes.NextNextMeetingAtTick, nextMeetingTime, meetingTimes.RobotIds));
+            _meetingPointVertexIdToMeetingTimesStigmergyComponent.SendAll();
             yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
         }
+
+        public IEnumerable<ComponentWaitForCondition> OnMeetingAnotherRobotAtMeeting(int meetingPointVertexId)
+        {
+            _missingRobot = null;
+
+            foreach (var waitForCondition in ExchangeInformation(meetingPointVertexId))
+            {
+                yield return waitForCondition;
+            }
+        }
+
 
         private int NextPossibleMeetingTime()
         {
@@ -233,16 +432,28 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
             return incomingvalueinfo;
         }
 
+        private static VirtualStigmergyComponent<int, MissingRobot, PartitionComponent>.ValueInfo OnMissingRobotConflict(int key, VirtualStigmergyComponent<int, MissingRobot, PartitionComponent>.ValueInfo localvalueinfo, VirtualStigmergyComponent<int, MissingRobot, PartitionComponent>.ValueInfo incomingvalueinfo)
+        {
+            if (localvalueinfo.RobotId < incomingvalueinfo.RobotId)
+            {
+                return localvalueinfo;
+            }
+
+            return incomingvalueinfo;
+        }
+
         private sealed class MeetingMessage
         {
             public int RobotId { get; }
 
             public int ProposedNextNextMeetingAtTick { get; }
+            public bool MightMissCurrentNextMeetingAtTick { get; }
 
-            public MeetingMessage(int robotId, int proposedNextNextMeetingAtTick)
+            public MeetingMessage(int robotId, int proposedNextNextMeetingAtTick, bool mightMissCurrentNextMeetingAtTick = false)
             {
                 RobotId = robotId;
                 ProposedNextNextMeetingAtTick = proposedNextNextMeetingAtTick;
+                MightMissCurrentNextMeetingAtTick = mightMissCurrentNextMeetingAtTick;
             }
         }
     }

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/PartitionComponent.cs
@@ -255,7 +255,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
         }
 
         private MissingRobot? _missingRobot;
-        
+
         public void DebugInfo(StringBuilder stringBuilder)
         {
             stringBuilder.AppendLine("PartitionComponent Debug Info:");

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs
@@ -1,6 +1,6 @@
 namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.TrackInfos
 {
-    public class ExchangeInfoAtMeetingTrackInfo : ITrackInfo
+    public class ExchangeInfoAtMeetingTrackInfo : IMeetingTrackInfo
     {
         public ExchangeInfoAtMeetingTrackInfo(MeetingComponent.Meeting meeting, int exchangeAtTick, int robotId)
         {

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/IMeetingTrackInfo.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/IMeetingTrackInfo.cs
@@ -1,0 +1,9 @@
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.TrackInfos
+{
+    public interface IMeetingTrackInfo : ITrackInfo
+    {
+        public MeetingComponent.Meeting Meeting { get; }
+        public int ExchangeAtTick { get; }
+        public int RobotId { get; }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/IMeetingTrackInfo.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/IMeetingTrackInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: acb7885a2f204a89905496d1a3980f17
+timeCreated: 1748259952

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/MissingRobotsAtMeetingTrackInfo.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/TrackInfos/MissingRobotsAtMeetingTrackInfo.cs
@@ -2,16 +2,21 @@ using System.Collections.Generic;
 
 namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.TrackInfos
 {
-    public class MissingRobotsAtMeetingTrackInfo : ITrackInfo
+    public class MissingRobotsAtMeetingTrackInfo : IMeetingTrackInfo
     {
-        public MissingRobotsAtMeetingTrackInfo(MeetingComponent.Meeting meeting, HashSet<int> missingRobotIds, int reportedByRobotId)
+        public MissingRobotsAtMeetingTrackInfo(MeetingComponent.Meeting meeting, int exchangeAtTick, int robotId,
+            HashSet<int> missingRobotIds, int reportedByRobotId)
         {
             Meeting = meeting;
             MissingRobotIds = missingRobotIds;
             ReportedByRobotId = reportedByRobotId;
+            ExchangeAtTick = exchangeAtTick;
+            RobotId = robotId;
         }
 
         public MeetingComponent.Meeting Meeting { get; }
+        public int ExchangeAtTick { get; }
+        public int RobotId { get; }
         public HashSet<int> MissingRobotIds { get; }
         public int ReportedByRobotId { get; }
     }

--- a/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingFaultToleranceV2Experiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingFaultToleranceV2Experiment.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 
 using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2;
+using Maes.FaultInjections.DestroyRobots;
 using Maes.Map.Generators;
 using Maes.Map.Generators.Patrolling.Waypoints.Generators;
 using Maes.Robot;
@@ -71,7 +72,8 @@ namespace Maes.Experiments.Patrolling
                     mapSpawner: generator => generator.GenerateMap(mapConfig),
                     robotConstraints: robotConstraints,
                     statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
-                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
+                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap,
+                    faultInjection: new DestroyRobotsAtSpecificTickFaultInjection(seed, 500, 20000))
             );
 
             var simulator = new MySimulator(scenarios);

--- a/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingFaultToleranceV2Experiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingFaultToleranceV2Experiment.cs
@@ -39,7 +39,7 @@ namespace Maes.Experiments.Patrolling
     {
         private void Start()
         {
-            const int robotCount = 4;
+            const int robotCount = 6;
             const int seed = 123;
             const int mapSize = 100;
             const string algoName = "HMPPatrollingAlgorithm";
@@ -60,7 +60,7 @@ namespace Maes.Experiments.Patrolling
             scenarios.Add(
                 new MySimulationScenario(
                     seed: seed,
-                    totalCycles: 4,
+                    totalCycles: 100,
                     stopAfterDiff: false,
                     robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
                         collisionMap: buildingConfig,

--- a/Assets/Scripts/GlobalSettings.cs
+++ b/Assets/Scripts/GlobalSettings.cs
@@ -40,7 +40,7 @@ namespace Maes
         public static readonly bool DrawCommunication;
 
         // Statistics
-        public static readonly bool ShouldWriteCsvResults = true;
+        public static readonly bool ShouldWriteCsvResults = false;
         public static readonly string StatisticsOutPutPath = "data/";
         public static readonly int TicksPerStatsSnapShot = 1;
         public static readonly bool PopulateAdjacencyAndComGroupsEveryTick;
@@ -76,7 +76,7 @@ namespace Maes
             LogicTickDeltaMillis = config.GlobalSettings.LogicTicksDeltaMillis;
             PhysicsTickDeltaMillis = config.GlobalSettings.PhysicsTicksPerLogicUpdate;
             DrawCommunication = config.GlobalSettings.DrawCommunication;
-            ShouldWriteCsvResults = config.GlobalSettings.ShouldWriteCsvResults;
+            ShouldWriteCsvResults = false;
             if (config.GlobalSettings.StatisticsResultPath.Length == 0)
             {
                 // Puts results file in same dir as the executable is run from

--- a/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
@@ -94,8 +94,11 @@ namespace Maes.Statistics.Trackers
                         $"{v.Vertex.Position.x}_{v.Vertex.Position.y}"))).ToArray();
             }
 
-            _writerThread = new Thread(WriterThread) { Priority = ThreadPriority.BelowNormal };
-            _writerThread.Start(_cancellationTokenSource.Token);
+            if (GlobalSettings.ShouldWriteCsvResults)
+            {
+                _writerThread = new Thread(WriterThread) { Priority = ThreadPriority.BelowNormal };
+                _writerThread.Start(_cancellationTokenSource.Token);
+            }
         }
 
         private void WriterThread(object cancellationTokenObject)
@@ -177,8 +180,11 @@ namespace Maes.Statistics.Trackers
 
         public override void FinishStatistics()
         {
-            _snapshots.CompleteAdding();
-            _writerThread.Join();
+            if (GlobalSettings.ShouldWriteCsvResults)
+            {
+                _snapshots.CompleteAdding();
+                _writerThread.Join();
+            }
         }
 
         protected override void OnLogicUpdate(List<MonaRobot> robots)

--- a/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/PatrollingTracker.cs
@@ -94,11 +94,8 @@ namespace Maes.Statistics.Trackers
                         $"{v.Vertex.Position.x}_{v.Vertex.Position.y}"))).ToArray();
             }
 
-            if (GlobalSettings.ShouldWriteCsvResults)
-            {
-                _writerThread = new Thread(WriterThread) { Priority = ThreadPriority.BelowNormal };
-                _writerThread.Start(_cancellationTokenSource.Token);
-            }
+            _writerThread = new Thread(WriterThread) { Priority = ThreadPriority.BelowNormal };
+            _writerThread.Start(_cancellationTokenSource.Token);
         }
 
         private void WriterThread(object cancellationTokenObject)

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults.meta
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 16a5e6c096794e058261ec5710e346d5
+timeCreated: 1748258861

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs
@@ -94,7 +94,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests.
                 Debug.Log(meetingTracker.NumberOfExchangeInfoAtMeetingTrackInfos + " exchange info at meeting track infos");
                 yield return null;
             }
-            
+
             Debug.Log(meetingTracker.NumberOfExchangeInfoAtMeetingTrackInfos + " exchange info at meeting track infos");
 
             /*meetingTracker.AssertMeetingHasBeenHeld(meetingPoints, meetingTimes);
@@ -145,11 +145,11 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests.
 
         public void AssertMeetingHasBeenHeld(int numberOfTimesHeld)
         {
-            
-            
-            
-            
-            
+
+
+
+
+
             /*foreach (var meetingPoint in meetingPoints)
             {
                 Assert.IsTrue(_heldMeetingAtMeetingPoint.TryGetValue(meetingPoint, out var attendedRobotsAtTick),

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs
@@ -1,0 +1,190 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using Maes.Algorithms.Patrolling;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.MeetingPoints;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2.TrackInfos;
+using Maes.Map.Generators.Patrolling.Waypoints.Connectors;
+using Maes.Robot;
+using Maes.Simulation.Patrolling;
+
+using NUnit.Framework;
+
+using Tests.EditModeTests.Utilities.MapInterpreter.MapBuilder;
+
+using UnityEngine;
+
+namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
+
+namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests.HMPFaults
+{
+    public class HMPFaultV2OneRobotDestroy : MonoBehaviour
+    {
+        private PatrollingSimulator _simulator;
+        private readonly RobotConstraints _robotConstraints = new(
+            mapKnown: true,
+            distributeSlam: false,
+            slamRayTraceRange: 0f,
+            robotCollisions: false,
+            calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls == 0f);
+
+
+        [TearDown]
+        public void ClearSimulator()
+        {
+            _simulator.Destroy();
+        }
+
+        private PatrollingSimulation EnqueueScenario(string mapString, int robotCount, int totalCycles, int spawnAtVertexId, int seed = 1)
+        {
+            var (simulationMap, patrollingMap, verticesByPartitionId) = new PartitionSimulationMapBuilder(mapString, AllConnectedWaypointConnector.ConnectVertices, '\n').Build();
+
+            const string algoName = "HMPPatrollingAlgorithmFault";
+            var mapWidth = simulationMap.WidthInTiles;
+
+            var spawnAtVertexPosition = patrollingMap.Vertices[spawnAtVertexId].Position;
+
+            var scenario =
+                new PatrollingSimulationScenario(
+                    seed: seed,
+                    totalCycles: totalCycles,
+                    stopAfterDiff: false,
+                    robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
+                        collisionMap: buildingConfig,
+                        seed: seed,
+                        numberOfRobots: robotCount,
+                        suggestedStartingPoint: spawnAtVertexPosition,
+                        createAlgorithmDelegate: (_) => new HMPPatrollingAlgorithm()),
+                    mapSpawner: _ => simulationMap,
+                    patrollingMapFactory: _ => patrollingMap,
+                    robotConstraints: _robotConstraints,
+                    statisticsFileName: $"{algoName}-seed-{seed}-size-{mapWidth}-robots-{robotCount}-RandomRobotSpawn")
+            ;
+
+            _simulator = new PatrollingSimulator(new[] { scenario });
+
+            return _simulator.SimulationManager.CurrentSimulation;
+        }
+
+        [Test(ExpectedResult = null)]
+        public IEnumerator Test_DestroyOneRobot_TakeOverTheDestroyRobot()
+        {
+            var mapString = MeetAtTheMeetingPointTest.GetStringMapFromFile("TestMap2.txt");
+            const int spawnAtVertexId = 6;
+            const int robotCount = 2;
+            const int totalCycles = 500;
+
+            var simulation = EnqueueScenario(mapString, robotCount, totalCycles, spawnAtVertexId);
+            var meetingTracker = new MeetingTracker(simulation.Robots);
+
+            _simulator.SimulationManager.AttemptSetPlayState(Maes.UI.SimulationPlayState.FastAsPossible);
+
+            // Waiting for the robots has their partition information
+            while (simulation.SimulatedLogicTicks <= 3)
+            {
+                yield return null;
+            }
+
+            var meetingPoints = meetingTracker.GetMeetingPoints(simulation.Robots);
+
+            // TODO: Make a better stop condition
+            while (!simulation.HasFinishedSim())
+            {
+                yield return null;
+            }
+
+            meetingTracker.AssertMeetingHasBeenHeld(meetingPoints, meetingTimes);
+            Assert.AreEqual(expectedNumberOfExchangeInfoAtMeetingTrackInfos, meetingTracker.NumberOfExchangeInfoAtMeetingTrackInfos, "Number of exchanged information is not equal to 2.");
+        }
+    }
+
+    public class MeetingTracker
+    {
+        public MeetingTracker(IReadOnlyList<MonaRobot> robots)
+        {
+            foreach (var robot in robots)
+            {
+                SubscribeToMeetingEvent(robot);
+            }
+        }
+
+        // Dictionary to track the meeting that has been held at the meeting point and the robots that attended at the meeting
+        private readonly Dictionary<(int Id, int MeetingAtTick), List<ExchangeInfoAtMeetingTrackInfo>> _heldMeetingAtMeetingPoint = new();
+        public int NumberOfExchangeInfoAtMeetingTrackInfos { get; private set; } = 0;
+
+        private void TrackMeeting(ITrackInfo trackInfo)
+        {
+            var key = (trackInfo.Meeting.Vertex.Id, trackInfo.Meeting.MeetingAtTick);
+            if (!_heldMeetingAtMeetingPoint.TryGetValue(key, out var attendedRobots))
+            {
+                attendedRobots = new List<ExchangeInfoAtMeetingTrackInfo>();
+                _heldMeetingAtMeetingPoint[key] = attendedRobots;
+            }
+
+            attendedRobots.Add(trackInfo);
+        }
+
+        private void SubscribeToMeetingEvent(MonaRobot robot)
+        {
+            if (robot.Algorithm is HMPPatrollingAlgorithm algorithm)
+            {
+                algorithm.SubscribeOnTrackInfo(trackInfo =>
+                {
+                    TrackMeeting(meetingTrackInfo);
+                    NumberOfExchangeInfoAtMeetingTrackInfos++;
+                });
+            }
+        }
+
+        public void AssertMeetingHasBeenHeld(IReadOnlyCollection<MeetingPoint> meetingPoints, int numberOfTimesHeld)
+        {
+            foreach (var meetingPoint in meetingPoints)
+            {
+                Assert.IsTrue(_heldMeetingAtMeetingPoint.TryGetValue(meetingPoint, out var attendedRobotsAtTick),
+                    $"There has never been any meetings at {meetingPoint}");
+
+                var i = 0;
+                foreach (var (_, exchangeInfoAtMeetingTrackInfos) in attendedRobotsAtTick.OrderBy(kvp => kvp.Key))
+                {
+                    // Check if the meeting was held at the correct tick or before the actual meeting tick
+                    var expectedMeetingWithInTick = meetingPoint.InitialMeetingAtTick + meetingPoint.MeetingAtEveryTick * i;
+                    foreach (var info in exchangeInfoAtMeetingTrackInfos)
+                    {
+                        Assert.LessOrEqual(info.ExchangeAtTick, expectedMeetingWithInTick,
+                            $"robot id {info.RobotId} has exchanged its information later then the meeting time");
+                    }
+
+                    Assert.AreEqual(meetingPoint.RobotIds.Count, exchangeInfoAtMeetingTrackInfos.Count,
+                        "The number of robots that attended the meeting is not equal to the number of robots that should have attended");
+
+                    // Check if the robots that attended the meeting are the same as the ones that should have attended
+                    CollectionAssert.AreEquivalent(exchangeInfoAtMeetingTrackInfos.Select(info => info.RobotId),
+                        meetingPoint.RobotIds, "the robots that attended the meeting are not the same as the ones that should have attended");
+
+                    i++;
+                }
+
+                Assert.AreEqual(numberOfTimesHeld, attendedRobotsAtTick.Count, "The number of times the meeting was held is not equal to the number of times it should have been held");
+            }
+        }
+
+        public HashSet<MeetingPoint> GetMeetingPoints(IEnumerable<MonaRobot> robots)
+        {
+            var meetingPoints = new HashSet<MeetingPoint>();
+            foreach (var robot in robots)
+            {
+                var algorithm = robot.Algorithm as HMPPatrollingAlgorithm;
+                Assert.IsNotNull(algorithm, "Algorithm is not of type HMPPatrollingAlgorithm.");
+
+                foreach (var meetingPoint in algorithm.PartitionInfo.MeetingPoints)
+                {
+                    meetingPoints.Add(meetingPoint);
+                }
+            }
+
+            return meetingPoints;
+        }
+    }
+}

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs.meta
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/HMPFaults/HMPFaultV2OneRobotDestroy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8d25544a470a416d8f76b89b6052ec68
+timeCreated: 1748259020

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/MeetAtTheMeetingPointTest.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/MeetAtTheMeetingPointTest.cs
@@ -35,7 +35,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
             _simulator.Destroy();
         }
 
-        private static string GetStringMapFromFile(string fileName)
+        public static string GetStringMapFromFile(string fileName)
         {
             var path = Path.Combine(Application.dataPath, "Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/TestMaps", fileName);
             return File.ReadAllText(path);

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/TestMaps/TestMap2.txt
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/TestMaps/TestMap2.txt
@@ -1,0 +1,50 @@
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+X                       X                                                X                       X
+X                       X                                                X                       X
+X          0            X            1              12           2       X                       X
+X                       X                                                X                       X
+X                       X                                                X     3                 X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X          0            X            1            X          2           X                       X
+X                       X                         X                      X             3         X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X          2           X                       X
+X                       X                         X                      X           3           X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X          0            X            1            X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                       X                         X                      X                       X
+X                                                 X                                              X
+X                                                 X                                              X
+X                                                 X                                              X
+X                             01                  X                                              X
+X                                                 X                             23               X
+X                                                 X                                              X
+X                                                 X                                              X
+X                                                 X                                              X
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/TestMaps/TestMap2.txt.meta
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/TestMaps/TestMap2.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 33481aca1fde5423cb02153925e89427
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The HMP algorithm v2 fault allows to have one fault robot at a time, and it takes four meetingcycle for a robot to take the fault robot partition and that information is know to the neighbour of the fault robot. 

Depends on #494 and #515