### PR TITLE
1 seed version of the GroupAMapSizeToRobotCountRatio1SeedExperiment

### DIFF
--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatio1SeedExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatio1SeedExperiment.cs
@@ -38,9 +38,9 @@ namespace Maes.Experiments.Patrolling
     /// AAU group cs-25-ds-10-17
     /// </summary>
     [Preserve]
-    internal class GroupAMapSizeToRobotCountRatioHMPVariantExperiment : MonoBehaviour
+    internal class GroupAMapSizeToRobotCountRatio1SeedExperiment : MonoBehaviour
     {
-        private static readonly List<int> _mapSizes = new() { 100, 150, 200, 250, 300 };
+        private static readonly List<int> _mapSizes = new() { 100, 150, 200, 250 };
         private static readonly List<int> _robotCounts = new() { 1, 2, 4, 8, 16 };
         private static readonly IEnumerable<string> scenarioFilters = new List<string>
         {
@@ -51,11 +51,11 @@ namespace Maes.Experiments.Patrolling
         private void Start()
         {
             var scenarios = new List<MySimulationScenario>();
-            foreach (var seed in GroupAParameters.SeedGenerator(5))
+            foreach (var seed in GroupAParameters.SeedGenerator(1))
             {
                 foreach (var mapSize in _mapSizes)
                 {
-                    foreach (var (algorithmName, lambda) in GroupAParameters.FaultTolerantHMPVariants)
+                    foreach (var (algorithmName, lambda) in GroupAParameters.AllAlgorithms)
                     {
                         foreach (var robotCount in _robotCounts)
                         {

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatio1SeedExperiment.cs.meta
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatio1SeedExperiment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 38943686a1b804049816d9a5c55f69b3

--- a/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioHMPVariantExperiment.cs.meta
+++ b/Assets/Scripts/Experiments/Patrolling/GroupA/GroupAMapSizeToRobotCountRatioHMPVariantExperiment.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 22dda12104f86529d996555ddcf4fba3


### PR DESCRIPTION
Make a 1 seed version of the robot count to map size ratio experiment, to quickly run all permutations to check if there are any issues.

This takes ~2 hours to run, contrary to the normal experiment which takes ~20 hours. Given 180 instances.