### PR TITLE
Add HMP Single Meeting point variant

### DIFF
--- a/Assets/Scenes/Patrolling/HMPPartitionVariants/SingleMeetingPoint.unity
+++ b/Assets/Scenes/Patrolling/HMPPartitionVariants/SingleMeetingPoint.unity
@@ -1,0 +1,170 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1223633425
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1223633427}
+  - component: {fileID: 1223633426}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1223633426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1223633425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 950a656793b84ba2b70326423fbb6b5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1223633427
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1223633425}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1223633427}

--- a/Assets/Scenes/Patrolling/HMPPartitionVariants/SingleMeetingPoint.unity.meta
+++ b/Assets/Scenes/Patrolling/HMPPartitionVariants/SingleMeetingPoint.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e8c33131781ea8de3a1c01cc4f049bfd
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20edb71d90f8584ed954bcc11ff4613c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/HMPPatrollingAlgorithm.cs
@@ -1,0 +1,403 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+//
+// Contributors 2025: 
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Maes.Algorithms.Patrolling.Components;
+using Maes.Algorithms.Patrolling.HeuristicConscientiousReactive;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.MeetingPoints;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.TrackInfos;
+using Maes.Map;
+using Maes.Map.Generators.Patrolling.Partitioning;
+using Maes.Robot;
+using Maes.Utilities;
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint
+{
+    /// <summary>
+    /// Partition-based patrolling algorithm with the use of meeting points in a limited communication range.
+    /// Proposed by Henrik, Mads, and Puvikaran. 
+    /// </summary>
+    public sealed class HMPPatrollingAlgorithm : PatrollingAlgorithm
+    {
+        public HMPPatrollingAlgorithm(int seed = 0)
+        {
+            _heuristicConscientiousReactiveLogic = new HeuristicConscientiousReactiveLogic(DistanceMethod, seed);
+        }
+        public override string AlgorithmName => "HMPAlgorithm";
+
+        public IEnumerable<int> VerticesByIdToPatrol => _partitionComponent.VerticesByIdToPatrol;
+
+        private readonly Dictionary<int, Color32[]> _colorsByVertexId = new();
+        public override Dictionary<int, Color32[]> ColorsByVertexId
+        {
+            get
+            {
+                if (_colorsByVertexId.Keys.SetEquals(VerticesByIdToPatrol))
+                {
+                    return _colorsByVertexId;
+                }
+
+                _colorsByVertexId.Clear();
+                foreach (var vertex in VerticesByIdToPatrol)
+                {
+                    _colorsByVertexId[vertex] = new[] { Controller.Color };
+                }
+
+                return _colorsByVertexId;
+            }
+        }
+
+        private readonly HeuristicConscientiousReactiveLogic _heuristicConscientiousReactiveLogic;
+
+        private PartitionComponent _partitionComponent = null!;
+        private MeetingComponent _meetingComponent = null!;
+        private GoToNextVertexComponent _goToNextVertexComponent = null!;
+
+        protected override IComponent[] CreateComponents(IRobotController controller, PatrollingMap patrollingMap)
+        {
+            _partitionComponent = new PartitionComponent(controller, GeneratePartitions);
+            _goToNextVertexComponent = new GoToNextVertexComponent(NextVertex, this, controller, patrollingMap, GetInitialVertexToPatrol);
+            _meetingComponent = new MeetingComponent(-200, -200, () => LogicTicks, EstimateTime, patrollingMap, Controller, _partitionComponent, ExchangeInformation);
+
+            return new IComponent[] { _partitionComponent, _meetingComponent, _goToNextVertexComponent };
+        }
+
+        private int? EstimateTime(Vector2Int start, Vector2Int target)
+        {
+            return Controller.TravelEstimator.OverEstimateTime(start, target, dependOnBrokenBehaviour: false);
+        }
+
+        private Vertex GetInitialVertexToPatrol()
+        {
+            var vertices = PatrollingMap.Vertices.Where(vertex => VerticesByIdToPatrol.Contains(vertex.Id)).ToArray();
+
+            return vertices.GetClosestVertex(target => Controller.EstimateTimeToTarget(target, dependOnBrokenBehaviour: false) ?? int.MaxValue);
+        }
+
+        private Vertex NextVertex(Vertex currentVertex)
+        {
+            var suggestedVertex = _heuristicConscientiousReactiveLogic.NextVertex(currentVertex,
+                currentVertex.Neighbors.Where(vertex => VerticesByIdToPatrol.Contains(vertex.Id)).ToArray());
+
+            return _meetingComponent.NextVertex(currentVertex, suggestedVertex);
+        }
+
+        private IEnumerable<ComponentWaitForCondition> ExchangeInformation(MeetingComponent.Meeting meeting)
+        {
+            TrackInfo(new ExchangeInfoAtMeetingTrackInfo(meeting, LogicTicks, Controller.Id));
+            foreach (var condition in _partitionComponent.ExchangeInformation(meeting.Vertex.Id))
+            {
+                yield return condition;
+            }
+        }
+
+        private float DistanceMethod(Vertex source, Vertex target)
+        {
+            if (PatrollingMap.Paths.TryGetValue((source.Id, target.Id), out var path))
+            {
+                return path.Sum(p => Vector2Int.Distance(p.Start, p.End));
+            }
+
+            throw new Exception($"Path from {source.Id} to {target.Id} not found");
+        }
+
+        private Dictionary<int, PartitionInfo> GeneratePartitions(HashSet<int> robotIds)
+        {
+            var map = Controller.SlamMap.CoarseMap;
+            var collisionMap = MapUtilities.MapToBitMap(map);
+
+            var vertexIdByPosition = PatrollingMap.Vertices.ToDictionary(v => v.Position, v => v.Id);
+
+            var vertexPositions = vertexIdByPosition.Keys.ToList();
+            var distanceMatrix = MapUtilities.CalculateDistanceMatrix(collisionMap, vertexPositions);
+            var clusters =
+                SpectralBisectionPartitioningGenerator.Generator(distanceMatrix, vertexPositions, robotIds.Count);
+
+            var vertexIdsPartitions = clusters.Select(vertexPoints => vertexPoints.Select(point => vertexIdByPosition[point]).ToHashSet()).ToArray();
+
+            var robotIdsByPartitionId = GetRobotIdsByPartitionId(robotIds, vertexIdsPartitions);
+
+            var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
+
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+
+            var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
+
+            var partitionsWithDiametersById =
+                GetPartitionDiameters(partitionsWithMeetingPointsById, meetingRobotIdsByVertexId);
+
+            var meetingPointsByPartitionId = GetMeetingPointsByPartitionId(meetingRobotIdsByVertexId, partitionsWithDiametersById, robotIdsByPartitionId);
+
+            var hmpPartitionsById = new Dictionary<int, PartitionInfo>();
+            foreach (var (partitionId, partitionInfo) in partitionsWithMeetingPointsById)
+            {
+                foreach (var robotId in robotIdsByPartitionId[partitionId])
+                {
+                    hmpPartitionsById[robotId] = new PartitionInfo(partitionInfo.RobotId, partitionInfo.VertexIds, meetingPointsByPartitionId[partitionId], partitionsWithDiametersById[partitionId].Diameter);
+                }
+            }
+
+            return hmpPartitionsById;
+        }
+
+        private static Dictionary<int, List<int>> GetRobotIdsByPartitionId(HashSet<int> robotIds, HashSet<int>[] vertexIdsPartitions)
+        {
+            Dictionary<int, List<int>> robotIdsByPartitionId;
+
+            var numberOfRobots = robotIds.Count;
+            if (vertexIdsPartitions.Length < numberOfRobots)
+            {
+                robotIdsByPartitionId = new Dictionary<int, List<int>>();
+                var sortedPartitions = vertexIdsPartitions
+                    .Select((vertexIds, index) => (vertexIds, index))
+                    .OrderByDescending(partition => partition.vertexIds.Count)
+                    .ToArray();
+
+                for (var robotId = 0; robotId < numberOfRobots; robotId++)
+                {
+                    var j = robotId % vertexIdsPartitions.Length;
+                    var partitionId = sortedPartitions[j].index;
+
+                    if (robotIdsByPartitionId.TryGetValue(partitionId, out var ids))
+                    {
+                        ids.Add(robotId);
+                    }
+                    else
+                    {
+                        robotIdsByPartitionId.Add(partitionId, new List<int> { robotId });
+                    }
+                }
+            }
+            else
+            {
+                Debug.Assert(vertexIdsPartitions.Length == robotIds.Count);
+                robotIdsByPartitionId = robotIds.ToDictionary(id => id, id => new List<int> { id });
+            }
+
+            return robotIdsByPartitionId;
+        }
+
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        {
+            // Find vertex that is closest to all partitions.
+
+            var distanceMatrix = MapUtilities.CalculateDistanceMatrix(collisionMap,
+                partitions.Values.SelectMany(p => p.VertexIds)
+                    .Select(v => PatrollingMap.Vertices.Single(p => p.Id == v)).Select(v => v.Position).ToList());
+
+            Vertex? shortestVertex = null;
+            var shortestDistance = float.MaxValue;
+
+            foreach (var vertex in PatrollingMap.Vertices)
+            {
+                var distance = 0f;
+                foreach (var partition in partitions.Values)
+                {
+                    distance = Mathf.Max(distance, GetShortestDistanceVertex(vertex, partition));
+                }
+                if (distance < shortestDistance)
+                {
+                    shortestDistance = distance;
+                    shortestVertex = vertex;
+                }
+            }
+
+            return partitions.ToDictionary(kv => kv.Key, kv =>
+            {
+                var copy = new UnfinishedPartitionInfo(kv.Value.RobotId, new HashSet<int>(kv.Value.VertexIds));
+                copy.VertexIds.Add(shortestVertex!.Id);
+                return copy;
+            });
+
+
+            float GetShortestDistanceVertex(Vertex vertex, UnfinishedPartitionInfo partition)
+            {
+                var shortestDistance = float.MaxValue;
+
+                foreach (var partitionVertex in partition.VertexIds.Select(id =>
+                             PatrollingMap.Vertices.Single(p => p.Id == id)))
+                {
+                    if (partitionVertex == vertex)
+                    {
+                        return 0f;
+                    }
+
+                    var distance = distanceMatrix[(vertex.Position, partitionVertex.Position)];
+                    if (distance < shortestDistance)
+                    {
+                        shortestDistance = distance;
+                    }
+                }
+
+                return shortestDistance;
+            }
+        }
+
+        private static Dictionary<int, HashSet<int>> FindMeetingRobotsAtMeetingPoints(UnfinishedPartitionInfo[] partitions)
+        {
+            var meetingPointVertexByVertexId = new Dictionary<int, HashSet<int>>();
+
+            foreach (var (partition1, partition2) in partitions.Combinations())
+            {
+                var intersectionVertexIds =
+                    partition1.VertexIds
+                        .Intersect(partition2.VertexIds)
+                        .ToArray();
+
+                if (intersectionVertexIds.Length == 0)
+                {
+                    continue;
+                }
+
+                foreach (var vertexId in intersectionVertexIds)
+                {
+                    if (!meetingPointVertexByVertexId.TryGetValue(vertexId, out var meetingPoint))
+                    {
+                        meetingPoint = new HashSet<int>();
+                        meetingPointVertexByVertexId[vertexId] = meetingPoint;
+                    }
+
+                    meetingPoint.Add(partition1.RobotId);
+                    meetingPoint.Add(partition2.RobotId);
+                }
+            }
+
+            return meetingPointVertexByVertexId;
+        }
+
+        private Dictionary<int, List<MeetingPoint>> GetMeetingPointsByPartitionId(
+            Dictionary<int, HashSet<int>> meetingRobotIdsByVertexId, Dictionary<int, UnfinishedPartitionInfoWithDiameter> partitionsById, Dictionary<int, List<int>> robotIdsByPartitionId)
+        {
+            // We have only a single partition
+            if (partitionsById.Count == 1)
+            {
+                return new Dictionary<int, List<MeetingPoint>>()
+                {
+                    {partitionsById.Keys.Single(), new List<MeetingPoint>()}
+                };
+            }
+
+            var globalMeetingIntervalTicks = GetGlobalMeetingIntervalTicks(partitionsById);
+            var startMeetingAfterTicks = GetWhenToStartMeeting(partitionsById.Values);
+
+            var meetingPointsByPartitionId = new Dictionary<int, List<MeetingPoint>>();
+            foreach (var (vertexId, meetingPartitionIds) in meetingRobotIdsByVertexId)
+            {
+                var meetingRobotIds = meetingPartitionIds.SelectMany(partitionId => robotIdsByPartitionId[partitionId]).ToArray();
+                var meetingPoint = new MeetingPoint(vertexId, startMeetingAfterTicks + globalMeetingIntervalTicks, globalMeetingIntervalTicks, meetingRobotIds);
+                Debug.LogFormat("First meeting at tick: {0}, cycle interval: {1}", meetingPoint.FirstMeetingAtTick, meetingPoint.CycleIntervalTicks);
+                foreach (var partitionId in meetingPartitionIds)
+                {
+                    if (!meetingPointsByPartitionId.TryGetValue(partitionId, out var meetingPoints))
+                    {
+                        meetingPoints = new List<MeetingPoint>();
+                        meetingPointsByPartitionId[partitionId] = meetingPoints;
+                    }
+
+                    meetingPoints.Add(meetingPoint);
+                }
+            }
+
+            return meetingPointsByPartitionId;
+        }
+
+        private Dictionary<int, UnfinishedPartitionInfoWithDiameter> GetPartitionDiameters(
+            Dictionary<int, UnfinishedPartitionInfo> partitionsById,
+            Dictionary<int, HashSet<int>> meetingRobotIdsByVertexId)
+        {
+            return partitionsById.ToDictionary(kv => kv.Key, kv =>
+            {
+                var robotId = kv.Key;
+                var partitionInfo = kv.Value;
+                var numberOfMeetingPoints = meetingRobotIdsByVertexId
+                    .Count(m => m.Value.Contains(robotId));
+                var estimated = EstimatePartitionMeetingIntervalTicks(partitionInfo, numberOfMeetingPoints);
+                return new UnfinishedPartitionInfoWithDiameter(partitionInfo.RobotId, partitionInfo.VertexIds,
+                    estimated);
+            });
+        }
+
+        private int GetGlobalMeetingIntervalTicks(Dictionary<int, UnfinishedPartitionInfoWithDiameter> partitionsById)
+        {
+            return partitionsById.Values.Select(p => p.Diameter).Max();
+        }
+
+        private int EstimatePartitionMeetingIntervalTicks(UnfinishedPartitionInfo partition, int numberOdMeetingPoints)
+        {
+            var maxTravelTime = EstimateMaxTravelTimeForPartition(partition);
+            return 2 * (int)Math.Ceiling((double)partition.VertexIds.Count / numberOdMeetingPoints) * maxTravelTime;
+        }
+
+        private int EstimateMaxTravelTimeForPartition(UnfinishedPartitionInfo partition)
+        {
+            var maxTicks = 0;
+
+            var vertexPositions = PatrollingMap.Vertices
+                .Where(v => partition.VertexIds.Contains(v.Id))
+                .Select(v => v.Position)
+                .ToArray();
+
+            foreach (var (vertexPosition1, vertexPosition2) in vertexPositions.Combinations())
+            {
+                var ticks = EstimateTime(vertexPosition1, vertexPosition2);
+                if (ticks == null)
+                {
+                    continue;
+                }
+
+                maxTicks = Mathf.Max(maxTicks, ticks.Value);
+            }
+
+            return maxTicks;
+        }
+
+        private int GetWhenToStartMeeting(IEnumerable<UnfinishedPartitionInfoWithDiameter> partitionInfos)
+        {
+            var startMeetingAfterTicks = 0;
+
+            foreach (var partitionInfo in partitionInfos)
+            {
+                int? timeToClosestVertex = null;
+                foreach (var vertex in PatrollingMap.Vertices.Where(v => partitionInfo.VertexIds.Contains(v.Id)))
+                {
+                    var timeToTarget = EstimateTime(Controller.SlamMap.CoarseMap.GetCurrentPosition(), vertex.Position) ?? int.MaxValue;
+                    if (timeToClosestVertex == null || timeToTarget < timeToClosestVertex)
+                    {
+                        timeToClosestVertex = timeToTarget;
+                    }
+                }
+
+                if (timeToClosestVertex > startMeetingAfterTicks)
+                {
+                    startMeetingAfterTicks = timeToClosestVertex.Value;
+                }
+            }
+
+            return startMeetingAfterTicks;
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/HMPPatrollingAlgorithm.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/HMPPatrollingAlgorithm.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53f402884a1d0a6a08de1f87e4cccc62

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingComponent.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+using Maes.Algorithms.Patrolling.Components;
+using Maes.Map;
+using Maes.Robot;
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint
+{
+    public sealed class MeetingComponent : IComponent
+    {
+        public delegate int? EstimateTimeDelegate(Vector2Int start, Vector2Int target);
+
+        public delegate IEnumerable<ComponentWaitForCondition> ExchangeInformationAtMeetingDelegate(Meeting meeting);
+        public delegate IEnumerable<ComponentWaitForCondition> OnMissingRobotsAtMeetingDelegate(Meeting meeting, HashSet<int> missingRobotIds);
+
+        public MeetingComponent(int preUpdateOrder, int postUpdateOrder,
+            Func<int> getLogicTick,
+            EstimateTimeDelegate estimateTime,
+            PatrollingMap patrollingMap, IRobotController controller, PartitionComponent partitionComponent,
+            ExchangeInformationAtMeetingDelegate exchangeInformation)
+        {
+            PreUpdateOrder = preUpdateOrder;
+            PostUpdateOrder = postUpdateOrder;
+            _getLogicTick = getLogicTick;
+            _estimateTime = estimateTime;
+            _controller = controller;
+            _exchangeInformation = exchangeInformation;
+            _partitionComponent = partitionComponent;
+            _patrollingMap = patrollingMap;
+        }
+
+        public int PreUpdateOrder { get; }
+        public int PostUpdateOrder { get; }
+
+        private readonly Func<int> _getLogicTick;
+        private readonly EstimateTimeDelegate _estimateTime;
+        private readonly IRobotController _controller;
+        private readonly ExchangeInformationAtMeetingDelegate _exchangeInformation;
+        private readonly PartitionComponent _partitionComponent;
+        private readonly PatrollingMap _patrollingMap;
+
+        private Meeting _nextMeeting;
+        private Meeting? GoingToMeeting { get; set; }
+
+        [SuppressMessage("ReSharper", "IteratorNeverReturns")]
+        public IEnumerable<ComponentWaitForCondition> PreUpdateLogic()
+        {
+            _nextMeeting = GetNextMeeting();
+            while (true)
+            {
+                while (!GoingToMeeting.HasValue)
+                {
+                    // If any other robot is ready to go to the meeting, then this robot is also attending and aborting its current task.
+                    // Otherwise, doing it current task
+                    yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
+                }
+
+                var meeting = GoingToMeeting.Value;
+
+                // Wait until all other robots are at the meeting point
+                var ticksToWait = meeting.MeetingAtTick - _getLogicTick();
+                if (ticksToWait > 0)
+                {
+                    yield return ComponentWaitForCondition.WaitForLogicTicks(ticksToWait, shouldContinue: true);
+                }
+                else
+                {
+                    Debug.Log("Time has already passed!");
+                }
+
+                foreach (var waitForCondition in _exchangeInformation(meeting))
+                {
+                    yield return waitForCondition;
+                }
+
+                GoingToMeeting = null;
+                _nextMeeting = GetNextMeeting();
+            }
+        }
+
+        /// <summary>
+        /// Checks if the robot should go to the next vertex or the next meeting point.
+        /// </summary>
+        /// <param name="currentVertex">The vertex which the robot is at now</param>
+        /// <param name="suggestedVertexToPatrol">The next vertex that should be visited</param>
+        /// <returns>Returns the vertex that the robot should move to</returns>
+        public Vertex NextVertex(Vertex currentVertex, Vertex suggestedVertexToPatrol)
+        {
+            if (GoingToMeeting != null)
+            {
+                return currentVertex;
+            }
+
+            var ticksToPatrollingVertex = _estimateTime(currentVertex.Position, suggestedVertexToPatrol.Position);
+            var ticksFromPatrollingVertexToMeetingPoint = _estimateTime(suggestedVertexToPatrol.Position, _nextMeeting.Vertex.Position);
+
+            var totalTicks = (_getLogicTick() + ticksToPatrollingVertex + ticksFromPatrollingVertexToMeetingPoint) ?? int.MaxValue;
+
+            if (totalTicks < _nextMeeting.MeetingAtTick)
+            {
+                return suggestedVertexToPatrol;
+            }
+
+            GoingToMeeting = _nextMeeting;
+            return _nextMeeting.Vertex;
+
+        }
+
+        public void DebugInfo(StringBuilder stringBuilder)
+        {
+            if (GoingToMeeting != null)
+            {
+                stringBuilder.Append($"Going to meeting:\n");
+                stringBuilder.Append($"   Vertex Id: {GoingToMeeting.Value.Vertex.Id}\n");
+                stringBuilder.Append($"   Meeting at Tick: {GoingToMeeting.Value.MeetingAtTick}\n");
+            }
+            else
+            {
+                stringBuilder.Append("Not going to any meeting\n");
+            }
+        }
+
+        private Meeting GetNextMeeting()
+        {
+            // There are no meeting points, never meet.
+            if (!_partitionComponent.MeetingPointsByVertexId.Any())
+            {
+                Debug.LogWarning("There are no meeting points! Are there only one partition?");
+                return new Meeting(_patrollingMap.Vertices.First(), int.MaxValue);
+            }
+
+            var meetingPoint = _partitionComponent.MeetingPointsByVertexId.Values.Single();
+            var cycleIndex = (_getLogicTick() - meetingPoint.FirstMeetingAtTick) / meetingPoint.CycleIntervalTicks;
+            var nextMeetingTime = (cycleIndex + 1) * meetingPoint.CycleIntervalTicks + meetingPoint.FirstMeetingAtTick;
+
+            return new Meeting(_patrollingMap.Vertices.Single(v => v.Id == meetingPoint.VertexId), nextMeetingTime);
+        }
+
+        /// <summary>
+        /// Encapsulate the information of the next meeting for the robot.
+        /// </summary>
+        public readonly struct Meeting : IEquatable<Meeting>
+        {
+            public Meeting(Vertex vertex, int meetingAtTick)
+            {
+                Vertex = vertex;
+                MeetingAtTick = meetingAtTick;
+            }
+
+            public Vertex Vertex { get; }
+            public int MeetingAtTick { get; }
+            public bool Equals(Meeting other)
+            {
+                return Vertex.Id == other.Vertex.Id &&
+                       MeetingAtTick == other.MeetingAtTick;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is Meeting other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Vertex.Id, MeetingAtTick);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 785364f654e34525fa88ef300190bc6e
+timeCreated: 1745946971

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 342ff78bf155a2b45a1106cb0fc0d520
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints/MeetingPoint.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints/MeetingPoint.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+using Maes.Utilities;
+
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.MeetingPoints
+{
+    public readonly struct MeetingPoint : IEquatable<MeetingPoint>
+    {
+        public MeetingPoint(int vertexId, int firstMeetingAtTick, int cycleIntervalTicks,
+            IReadOnlyCollection<int> partitionIds)
+        {
+            VertexId = vertexId;
+            FirstMeetingAtTick = firstMeetingAtTick;
+            CycleIntervalTicks = cycleIntervalTicks;
+            PartitionIds = partitionIds;
+        }
+
+        public int VertexId { get; }
+        public int FirstMeetingAtTick { get; }
+        public int CycleIntervalTicks { get; }
+        public IReadOnlyCollection<int> PartitionIds { get; }
+
+        public bool Equals(MeetingPoint other)
+        {
+            return VertexId == other.VertexId && FirstMeetingAtTick == other.FirstMeetingAtTick && CycleIntervalTicks == other.CycleIntervalTicks && PartitionIds.SetEquals(other.PartitionIds);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MeetingPoint other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(VertexId, FirstMeetingAtTick, CycleIntervalTicks, PartitionIds);
+        }
+
+        public static bool operator ==(MeetingPoint left, MeetingPoint right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MeetingPoint left, MeetingPoint right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints/MeetingPoint.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/MeetingPoints/MeetingPoint.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0ee6db7f5d0ac8ac2858625d9225065a
+timeCreated: 1745346229

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionComponent.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionComponent.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+using Maes.Algorithms.Patrolling.Components;
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.MeetingPoints;
+using Maes.Map;
+using Maes.Robot;
+
+using UnityEngine;
+
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint
+{
+    public class PartitionComponent : IComponent
+    {
+        public delegate Dictionary<int, PartitionInfo> PartitionGenerator(HashSet<int> robots);
+
+        public PartitionComponent(IRobotController controller, PartitionGenerator partitionGenerator)
+        {
+            _robotId = controller.Id;
+            _robotController = controller;
+            _partitionGenerator = partitionGenerator;
+        }
+
+        public int PreUpdateOrder => -900;
+        public int PostUpdateOrder => -900;
+
+        public IReadOnlyDictionary<int, MeetingPoint> MeetingPointsByVertexId { get; private set; } = null!;
+
+        private readonly HashSet<int> _verticesByIdToPatrol = new();
+        public HashSet<int> VerticesByIdToPatrol
+        {
+            get
+            {
+                _verticesByIdToPatrol.Clear();
+                var partitions = GetPartitionsPatrolledByRobotId(_robotId);
+                foreach (var partition in partitions)
+                {
+                    foreach (var vertexId in _partitions[partition].VertexIds)
+                    {
+                        _verticesByIdToPatrol.Add(vertexId);
+                    }
+                }
+
+                return _verticesByIdToPatrol;
+            }
+        }
+
+        private readonly int _robotId;
+        private readonly IRobotController _robotController;
+        private readonly PartitionGenerator _partitionGenerator;
+
+        private PartitionInfo[] _partitions = null!;
+
+        private StartupComponent<IReadOnlyDictionary<int, PartitionInfo>, PartitionComponent> _startupComponent = null!;
+
+        private VirtualStigmergyComponent<int, int, PartitionComponent> _partitionIdToRobotIdVirtualStigmergyComponent =
+            null!;
+
+
+        public IComponent[] CreateComponents(IRobotController controller, PatrollingMap patrollingMap)
+        {
+            _startupComponent = new StartupComponent<IReadOnlyDictionary<int, PartitionInfo>, PartitionComponent>(controller, robots => _partitionGenerator(robots));
+            _partitionIdToRobotIdVirtualStigmergyComponent = new(OnPartitionConflict, controller);
+
+            return new IComponent[] { _startupComponent, _partitionIdToRobotIdVirtualStigmergyComponent };
+        }
+
+        [SuppressMessage("ReSharper", "IteratorNeverReturns")]
+        public IEnumerable<ComponentWaitForCondition> PreUpdateLogic()
+        {
+            var meetingPointsByVertexId = new Dictionary<int, MeetingPoint>();
+            var partitions = _startupComponent.Message;
+
+            _partitions = new PartitionInfo[partitions.Count];
+
+            var partitionId = 0;
+            foreach (var (robotId, partition) in partitions)
+            {
+                // Set up partition robot assignments
+                _partitionIdToRobotIdVirtualStigmergyComponent.Put(partitionId, robotId);
+                _partitions[partitionId] = partition;
+
+
+                // Set up meeting points
+                foreach (var meetingPoint in partition.MeetingPoints)
+                {
+                    meetingPointsByVertexId[meetingPoint.VertexId] = meetingPoint;
+                }
+
+                partitionId++;
+            }
+
+            MeetingPointsByVertexId = meetingPointsByVertexId;
+
+            while (true)
+            {
+                yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: true);
+            }
+        }
+
+        public IEnumerable<ComponentWaitForCondition> ExchangeInformation(int meetingPointVertexId)
+        {
+            _robotController.Broadcast(new MeetingMessage(_robotId));
+
+            yield return ComponentWaitForCondition.WaitForLogicTicks(1, shouldContinue: false);
+
+            var meetingMessages = _robotController.ReceiveBroadcast().OfType<MeetingMessage>().ToList();
+
+            // Lets see if we actually should take over the partition
+
+            var expectedRobotIds = MeetingPointsByVertexId[meetingPointVertexId].PartitionIds.Select(p =>
+            {
+                var success = _partitionIdToRobotIdVirtualStigmergyComponent.TryGetNonSending(p, out var assignedRobot);
+                Debug.Assert(success);
+                return assignedRobot;
+            }).Distinct();
+
+            // TODO: Optimize who takes over (remember that the information must be available and correct on all robots attending meeting!)
+            var notMissingRobots = meetingMessages.Select(m => m.RobotId).Append(_robotId).OrderBy(id => GetPartitionsPatrolledByRobotId(id).Count()).ThenBy(id => id);
+            var missingRobots = expectedRobotIds
+                .Where(id => notMissingRobots.All(notMissingId => notMissingId != id)).OrderByDescending(id => GetPartitionsPatrolledByRobotId(id).Count()).ThenByDescending(id => id);
+
+            var overtaking = missingRobots.Zip(notMissingRobots,
+                (missingId, notMissingId) => (missingId, notMissingId));
+
+            // If not every expected robot showed up
+            if (expectedRobotIds.Count() - 1 != meetingMessages.Count)
+            {
+                Debug.LogFormat("Vertex {0}, Missing robots: {1}", meetingPointVertexId, string.Join(", ", missingRobots));
+
+                foreach (var (missingId, overtakingId) in overtaking)
+                {
+                    if (overtakingId == _robotId)
+                    {
+                        var overtakingPartitions = GetPartitionsPatrolledByRobotId(missingId);
+                        Debug.LogFormat("Robot {0} is taking over partitions: {1}", _robotId, string.Join(", ", overtakingPartitions));
+                        foreach (var overtakingPartition in overtakingPartitions)
+                        {
+                            _partitionIdToRobotIdVirtualStigmergyComponent.Put(overtakingPartition, _robotId);
+                        }
+                    }
+                }
+            }
+
+            /*
+            var giveAndTakeCandidates = notMissingRobots.Where(c => !overtaking.Any(tuple => tuple.notMissingId == c));
+            var giveCandidates = giveAndTakeCandidates.OrderByDescending(c => GetPartitionsPatrolledByRobotId(c).Count()).ThenBy(c => c).Take(giveAndTakeCandidates.Count() / 2);
+            var takeCandidates = giveAndTakeCandidates.OrderBy(c => GetPartitionsPatrolledByRobotId(c).Count())
+                .ThenByDescending(c => c).Take(giveAndTakeCandidates.Count() / 2);
+
+            var giveTakePairs = giveCandidates.Zip(takeCandidates, (giveRobot, takeRobot) => (giveRobot, takeRobot))
+                .Where(tuple =>
+                    tuple.giveRobot != tuple.takeRobot &&
+                    // Don't shuffle partitions back and forth
+                    GetPartitionsPatrolledByRobotId(tuple.giveRobot).Count() - 1 >
+                    GetPartitionsPatrolledByRobotId(tuple.takeRobot).Count());
+
+            // Let somebody give a partition to somebody else
+            foreach (var (giveRobot, takeRobot) in giveTakePairs)
+            {
+                // There might actually be multiple partitions matching this. So lets just get the first.
+                var partition = GetPartitionsPatrolledByRobotId(giveRobot).Select(p => _partitions[p])
+                    .First(p => p.MeetingPoints.Any(m => m.VertexId == meetingPointVertexId)).PartitionId;
+
+                if (giveRobot == _robotId)
+                {
+                    Debug.LogFormat("Robot {0} is giving partition {1} away", _robotId, partition);
+                    _partitionIdToRobotIdVirtualStigmergyComponent.Put(partition, -1);
+                }
+                else if (takeRobot == _robotId)
+                {
+                    Debug.LogFormat("Robot {0} is taking partition {1}", _robotId, partition);
+                    Debug.Assert(_overTakingMeetingPoint == -1);
+                    _overTakingMeetingPoint = meetingPointVertexId;
+                    _overTakingPartitions.Add(partition);
+                }
+            }
+            */
+        }
+
+        private IEnumerable<int> GetPartitionsPatrolledByRobotId(int robotId)
+        {
+            for (var partitionId = 0; partitionId < _partitions.Length; partitionId++)
+            {
+                var success =
+                    _partitionIdToRobotIdVirtualStigmergyComponent.TryGetNonSending(partitionId,
+                        out var assignedRobotId);
+                Debug.Assert(success);
+
+                if (assignedRobotId == robotId)
+                {
+                    yield return partitionId;
+                }
+            }
+        }
+
+        private static VirtualStigmergyComponent<int, int, PartitionComponent>.ValueInfo OnPartitionConflict(int key, VirtualStigmergyComponent<int, int, PartitionComponent>.ValueInfo localvalueinfo, VirtualStigmergyComponent<int, int, PartitionComponent>.ValueInfo incomingvalueinfo)
+        {
+            if (localvalueinfo.RobotId < incomingvalueinfo.RobotId)
+            {
+                return localvalueinfo;
+            }
+
+            return incomingvalueinfo;
+        }
+
+        private sealed class MeetingMessage
+        {
+            public int RobotId { get; }
+
+            public MeetingMessage(int robotId)
+            {
+                RobotId = robotId;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionComponent.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3913b6d9bf2fd644996e6835bd7015dd
+timeCreated: 1743416087

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionInfo.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionInfo.cs
@@ -1,0 +1,81 @@
+// Copyright 2025 MAEPS
+// 
+// This file is part of MAEPS
+// 
+// MAEPS is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// MAEPS is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+// Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along
+// with MAEPS. If not, see http://www.gnu.org/licenses/.
+//
+// Contributors 2025: 
+// Henrik van Peet,
+// Mads Beyer Mogensen,
+// Puvikaran Santhirasegaram
+
+using System.Collections.Generic;
+
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.MeetingPoints;
+using Maes.Utilities;
+
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint
+{
+    public readonly struct UnfinishedPartitionInfo
+    {
+        public int RobotId { get; }
+
+        public HashSet<int> VertexIds { get; }
+
+        public UnfinishedPartitionInfo(int robotId, HashSet<int> vertexIds)
+        {
+            RobotId = robotId;
+            VertexIds = vertexIds;
+        }
+    }
+
+    public readonly struct UnfinishedPartitionInfoWithDiameter
+    {
+        public int RobotId { get; }
+
+        public HashSet<int> VertexIds { get; }
+
+        public int Diameter { get; }
+
+        public UnfinishedPartitionInfoWithDiameter(int robotId, HashSet<int> vertexIds, int diameter)
+        {
+            RobotId = robotId;
+            VertexIds = vertexIds;
+            Diameter = diameter;
+        }
+    }
+
+    public sealed class PartitionInfo : ICloneable<PartitionInfo>
+    {
+        public PartitionInfo(int partitionId, IReadOnlyCollection<int> vertexIds, IReadOnlyList<MeetingPoint> meetingPoints, int diameter)
+        {
+            PartitionId = partitionId;
+            VertexIds = vertexIds;
+            MeetingPoints = meetingPoints;
+            Diameter = diameter;
+        }
+
+        public int PartitionId { get; }
+        public IReadOnlyCollection<int> VertexIds { get; }
+        public IReadOnlyList<MeetingPoint> MeetingPoints { get; }
+
+        public int Diameter { get; }
+
+        public PartitionInfo Clone()
+        {
+            // This class is immutable, therefore we can just return this.
+            return this;
+        }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionInfo.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/PartitionInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d8f008e5acf5123df889833d002b9c3c
+timeCreated: 1743076536

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b42527914b183a2379f11765d15ab430
+timeCreated: 1746450549

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs
@@ -1,0 +1,16 @@
+namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.TrackInfos
+{
+    public class ExchangeInfoAtMeetingTrackInfo : ITrackInfo
+    {
+        public ExchangeInfoAtMeetingTrackInfo(MeetingComponent.Meeting meeting, int exchangeAtTick, int robotId)
+        {
+            Meeting = meeting;
+            ExchangeAtTick = exchangeAtTick;
+            RobotId = robotId;
+        }
+
+        public MeetingComponent.Meeting Meeting { get; }
+        public int ExchangeAtTick { get; }
+        public int RobotId { get; }
+    }
+}

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs.meta
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/SingleMeetingPoint/TrackInfos/ExchangeInfoAtMeetingTrackInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 21b07f54e1c2c6c5f81ff30e43b5fea0
+timeCreated: 1746450553

--- a/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingSingleMeetingPointExperiment.cs
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingSingleMeetingPointExperiment.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+using Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint;
+using Maes.FaultInjections.DestroyRobots;
+using Maes.Map.Generators;
+using Maes.Map.Generators.Patrolling.Waypoints.Generators;
+using Maes.Robot;
+using Maes.Simulation.Patrolling;
+
+using UnityEngine;
+
+namespace Maes.Experiments.Patrolling
+{
+    using MySimulationScenario = PatrollingSimulationScenario;
+    using MySimulator = PatrollingSimulator;
+    internal class HMPPatrollingSingleMeetingPointExperiment : MonoBehaviour
+    {
+        private void Start()
+        {
+            const int robotCount = 6;
+            const int seed = 123;
+            const int mapSize = 100;
+            const string algoName = "HMPPatrollingAlgorithm";
+
+            const string constraintName = "local";
+            var robotConstraints = new RobotConstraints(
+                mapKnown: true,
+                distributeSlam: false,
+                slamRayTraceRange: 0f,
+                robotCollisions: false,
+                calculateSignalTransmissionProbability: (_, distanceThroughWalls) => distanceThroughWalls == 0f);
+
+            var scenarios = new List<MySimulationScenario>();
+
+
+            var mapConfig = new BuildingMapConfig(123, widthInTiles: mapSize, heightInTiles: mapSize, brokenCollisionMap: false);
+
+            scenarios.Add(
+                new MySimulationScenario(
+                    seed: seed,
+                    totalCycles: 100,
+                    stopAfterDiff: false,
+                    robotSpawner: (buildingConfig, spawner) => spawner.SpawnRobotsTogether(
+                        collisionMap: buildingConfig,
+                        seed: seed,
+                        numberOfRobots: robotCount,
+                        suggestedStartingPoint: null,
+                        createAlgorithmDelegate: _ => new HMPPatrollingAlgorithm()),
+                    mapSpawner: generator => generator.GenerateMap(mapConfig),
+                    robotConstraints: robotConstraints,
+                    faultInjection: new DestroyRobotsAtSpecificTickFaultInjection(seed, 10000, 20000, 25000),
+                    statisticsFileName: $"{algoName}-seed-{mapConfig.RandomSeed}-size-{mapSize}-comms-{constraintName}-robots-{robotCount}-SpawnTogether",
+                    patrollingMapFactory: AllWaypointConnectedGenerator.MakePatrollingMap)
+            );
+
+            var simulator = new MySimulator(scenarios);
+            simulator.PressPlayButton(); // Instantly enter play mode
+        }
+    }
+}

--- a/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingSingleMeetingPointExperiment.cs.meta
+++ b/Assets/Scripts/Experiments/Patrolling/HMPPartitionVariants/HMPPatrollingSingleMeetingPointExperiment.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 950a656793b84ba2b70326423fbb6b5b
+timeCreated: 1748856208

--- a/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/AllHMPPatrollingAlgorithm.cs
+++ b/Assets/Tests/PlayModeTests/Algorithms/Patrolling/HMPPatrollingAlgorithmTests/AllHMPPatrollingAlgorithm.cs
@@ -13,6 +13,7 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
     using ImmediateTakeOverAlgorithm = Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover.HMPPatrollingAlgorithm;
     using NoFaultToleranceAlgorithm = Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.NoFaultTolerance.HMPPatrollingAlgorithm;
     using RandomTakeoverAlgorithm = Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.RandomTakeover.HMPPatrollingAlgorithm;
+    using SingleMeetingPointAlgorithm = Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.SingleMeetingPoint.HMPPatrollingAlgorithm;
 
     public class AllHMPPatrollingAlgorithm
     {
@@ -23,7 +24,8 @@ namespace Tests.PlayModeTests.Algorithms.Patrolling.HMPPatrollingAlgorithmTests
             new AlgorithmFactory(() => new FaultToleranceV2Algorithm(), nameof(FaultToleranceV2Algorithm)),
             new AlgorithmFactory(() => new ImmediateTakeOverAlgorithm(PartitionComponent.TakeoverStrategy.ImmediateTakeoverStrategy), nameof(ImmediateTakeOverAlgorithm)),
             new AlgorithmFactory(() => new ImmediateTakeOverAlgorithm(PartitionComponent.TakeoverStrategy.QuasiRandomStrategy), nameof(ImmediateTakeOverAlgorithm)),
-            new AlgorithmFactory(() => new RandomTakeoverAlgorithm(), nameof(RandomTakeoverAlgorithm))
+            new AlgorithmFactory(() => new RandomTakeoverAlgorithm(), nameof(RandomTakeoverAlgorithm)),
+            new AlgorithmFactory(() => new SingleMeetingPointAlgorithm(), nameof(SingleMeetingPointAlgorithm))
         };
 
         public static IEnumerable TestCases


### PR DESCRIPTION
Every partition has a single meeting point all connected to each other. Robots no longer need to negotiate next meeting point as it is cycle interval based.
Robots instantly take over a partition if another robot is missing.