### PR TITLE
More optimizations

### DIFF
--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultTolerance/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultTolerance/HMPPatrollingAlgorithm.cs
@@ -155,7 +155,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultTolerance
 
             var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
 
-            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(partitionsWithNoMeetingPointsById, distanceMatrix);
 
             var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
 
@@ -213,10 +213,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultTolerance
             return robotIdsByPartitionId;
         }
 
-        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Dictionary<int, UnfinishedPartitionInfo> partitions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix)
         {
             var verticesReverseNearestNeighbors = PatrollingMap.Vertices.Select(v => new Vertex(v.Id, v.Position, v.Partition, v.Color)).ToArray();
-            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, collisionMap);
+            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, distanceMatrix);
 
             var neighborsPartitionsWithNoCommonVertices = GetNeighborsPartitionsWithNoCommonVertices(partitions, verticesReverseNearestNeighbors);
             foreach (var meetingPoint in neighborsPartitionsWithNoCommonVertices)

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/FaultToleranceV2/HMPPatrollingAlgorithm.cs
@@ -137,7 +137,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
             var robotIdsByPartitionId = GetRobotIdsByPartitionId(robotIds, vertexIdsPartitions);
             var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
 
-            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(partitionsWithNoMeetingPointsById, distanceMatrix);
 
             var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
 
@@ -195,10 +195,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.FaultToleranceV2
             return robotIdsByPartitionId;
         }
 
-        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Dictionary<int, UnfinishedPartitionInfo> partitions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix)
         {
             var verticesReverseNearestNeighbors = PatrollingMap.Vertices.Select(v => new Vertex(v.Id, v.Position, v.Partition, v.Color)).ToArray();
-            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, collisionMap);
+            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, distanceMatrix);
 
             var neighborsPartitionsWithNoCommonVertices = GetNeighborsPartitionsWithNoCommonVertices(partitions, verticesReverseNearestNeighbors);
             foreach (var meetingPoint in neighborsPartitionsWithNoCommonVertices)

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/ImmediateTakeover/HMPPatrollingAlgorithm.cs
@@ -145,7 +145,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
 
             var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
 
-            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(partitionsWithNoMeetingPointsById, distanceMatrix);
 
             var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
 
@@ -200,10 +200,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.ImmediateTakeover
             return robotIdsByPartitionId;
         }
 
-        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Dictionary<int, UnfinishedPartitionInfo> partitions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix)
         {
             var verticesReverseNearestNeighbors = PatrollingMap.Vertices.Select(v => new Vertex(v.Id, v.Position, v.Partition, v.Color)).ToArray();
-            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, collisionMap);
+            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, distanceMatrix);
 
             var neighborsPartitionsWithNoCommonVertices = GetNeighborsPartitionsWithNoCommonVertices(partitions, verticesReverseNearestNeighbors);
             foreach (var meetingPoint in neighborsPartitionsWithNoCommonVertices)

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/NoFaultTolerance/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/NoFaultTolerance/HMPPatrollingAlgorithm.cs
@@ -137,7 +137,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.NoFaultTolerance
 
             var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
 
-            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(partitionsWithNoMeetingPointsById, distanceMatrix);
 
             var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
 
@@ -192,10 +192,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.NoFaultTolerance
             return robotIdsByPartitionId;
         }
 
-        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Dictionary<int, UnfinishedPartitionInfo> partitions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix)
         {
             var verticesReverseNearestNeighbors = PatrollingMap.Vertices.Select(v => new Vertex(v.Id, v.Position, v.Partition, v.Color)).ToArray();
-            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, collisionMap);
+            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, distanceMatrix);
 
             var neighborsPartitionsWithNoCommonVertices = GetNeighborsPartitionsWithNoCommonVertices(partitions, verticesReverseNearestNeighbors);
             foreach (var meetingPoint in neighborsPartitionsWithNoCommonVertices)

--- a/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/RandomTakeover/HMPPatrollingAlgorithm.cs
+++ b/Assets/Scripts/Algorithms/Patrolling/HMPPatrollingAlgorithms/RandomTakeover/HMPPatrollingAlgorithm.cs
@@ -142,7 +142,7 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.RandomTakeover
 
             var partitionsWithNoMeetingPointsById = vertexIdsPartitions.Select((vertexIds, id) => (vertexIds, id)).ToDictionary(partition => partition.id, partition => new UnfinishedPartitionInfo(partition.id, partition.vertexIds));
 
-            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(collisionMap, partitionsWithNoMeetingPointsById);
+            var partitionsWithMeetingPointsById = AddMissingMeetingPointsForNeighborPartitions(partitionsWithNoMeetingPointsById, distanceMatrix);
 
             var meetingRobotIdsByVertexId = FindMeetingRobotsAtMeetingPoints(partitionsWithMeetingPointsById.Values.ToArray());
 
@@ -197,10 +197,10 @@ namespace Maes.Algorithms.Patrolling.HMPPatrollingAlgorithms.RandomTakeover
             return robotIdsByPartitionId;
         }
 
-        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Bitmap collisionMap, Dictionary<int, UnfinishedPartitionInfo> partitions)
+        private Dictionary<int, UnfinishedPartitionInfo> AddMissingMeetingPointsForNeighborPartitions(Dictionary<int, UnfinishedPartitionInfo> partitions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix)
         {
             var verticesReverseNearestNeighbors = PatrollingMap.Vertices.Select(v => new Vertex(v.Id, v.Position, v.Partition, v.Color)).ToArray();
-            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, collisionMap);
+            ReverseNearestNeighborWaypointConnector.ConnectVertices(verticesReverseNearestNeighbors, distanceMatrix);
 
             var neighborsPartitionsWithNoCommonVertices = GetNeighborsPartitionsWithNoCommonVertices(partitions, verticesReverseNearestNeighbors);
             foreach (var meetingPoint in neighborsPartitionsWithNoCommonVertices)

--- a/Assets/Scripts/Map/Generators/BuildingGenerator.cs
+++ b/Assets/Scripts/Map/Generators/BuildingGenerator.cs
@@ -44,6 +44,7 @@ namespace Maes.Map.Generators
         /// used in the Marching Squares Algorithm.</returns>
         public SimulationMap<Tile> GenerateBuildingMap(BuildingMapConfig config, float wallHeight = 2.0f)
         {
+            var timeStart = Time.realtimeSinceStartup;
             _config = config;
             _wallHeight = wallHeight;
             // Clear and destroy objects from previous map
@@ -73,9 +74,13 @@ namespace Maes.Map.Generators
             // mapToDraw = borderedMap;
 
             // The rooms should now reflect their relative shifted positions after adding borders round map.
-            rooms.ForEach(r => r.OffsetCoordsBy(_config.BorderSize, _config.BorderSize));
+            foreach (var r in rooms)
+            {
+                r.OffsetCoordsBy(_config.BorderSize, _config.BorderSize);
+            }
+
             var meshGen = GetComponent<MeshGenerator>();
-            var collisionMap = meshGen.GenerateMesh((Tile[,])borderedMap.Clone(), _wallHeight, true,
+            var collisionMap = meshGen.GenerateMesh(borderedMap, _wallHeight, true,
                 rooms, _config.BrokenCollisionMap);
 
             foreach (var room in rooms)
@@ -89,6 +94,8 @@ namespace Maes.Map.Generators
             ResizePlaneToFitMap(_config.BitMapHeight, _config.BitMapWidth);
 
             MovePlaneAndWallRoofToFitWallHeight(_wallHeight);
+
+            Debug.LogFormat("GenerateBuildingMap took {0}s (MeshGenerator is included)", Time.realtimeSinceStartup - timeStart);
 
             return collisionMap;
         }

--- a/Assets/Scripts/Map/Generators/CaveGenerator.cs
+++ b/Assets/Scripts/Map/Generators/CaveGenerator.cs
@@ -45,6 +45,8 @@ namespace Maes.Map.Generators
         /// used in the Marching Squares Algorithm.</returns>
         public SimulationMap<Tile> GenerateCaveMap(CaveMapConfig config, float wallHeight = 2.0f)
         {
+            var timeStart = Time.realtimeSinceStartup;
+
             _caveConfig = config;
             _wallHeight = wallHeight;
             var random = new Random(_caveConfig.RandomSeed);
@@ -56,6 +58,8 @@ namespace Maes.Map.Generators
             ResizePlaneToFitMap(_caveConfig.BitMapHeight, _caveConfig.BitMapWidth);
 
             MovePlaneAndWallRoofToFitWallHeight(_wallHeight);
+
+            Debug.LogFormat("GenerateCaveMap took {0}s (MeshGenerator is included)", Time.realtimeSinceStartup - timeStart);
 
             return collisionMap;
         }
@@ -96,7 +100,7 @@ namespace Maes.Map.Generators
             survivingRooms.ForEach(r => r.OffsetCoordsBy(caveConfig.BorderSize, caveConfig.BorderSize));
 
             var meshGen = GetComponent<MeshGenerator>();
-            var collisionMap = meshGen.GenerateMesh((Tile[,])borderedMap.Clone(), wallHeight,
+            var collisionMap = meshGen.GenerateMesh(borderedMap, wallHeight,
                 true, survivingRooms, _caveConfig.BrokenCollisionMap);
 
             foreach (var room in survivingRooms)

--- a/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitioningGenerator.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Partitioning/PartitioningGenerator.cs
@@ -63,7 +63,7 @@ namespace Maes.Map.Generators.Patrolling.Partitioning
 
             foreach (var cluster in clusters)
             {
-                var vertices = ReverseNearestNeighborWaypointConnector.ConnectVertices(map, cluster, nextId);
+                var vertices = ReverseNearestNeighborWaypointConnector.ConnectVertices(cluster, distanceMatrix, nextId);
 
                 // Assign the partition and color to each vertex in the cluster
                 var clusterColor = Random.ColorHSV(0f, 1f, 0.5f, 1f, 0.5f, 1f);

--- a/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
+++ b/Assets/Scripts/Map/Generators/Patrolling/Waypoints/Connectors/ReverseNearestNeighborWaypointConnector.cs
@@ -45,23 +45,20 @@ namespace Maes.Map.Generators.Patrolling.Waypoints.Connectors
         /// <param name="nextId">Used by partitioning.</param>
         /// <param name="numberOfReverseNearestNeighbors">The amount of RNN's to connect(make an edge) to the current vertex.</param>
         /// <returns>Vertices with connections(edges) to other vertices.</returns>
-        public static Vertex[] ConnectVertices(Bitmap map, IReadOnlyCollection<Vector2Int> vertexPositions, int nextId = 0, int numberOfReverseNearestNeighbors = 1)
+        public static Vertex[] ConnectVertices(IReadOnlyCollection<Vector2Int> vertexPositions, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix, int nextId = 0, int numberOfReverseNearestNeighbors = 1)
         {
             var startTime = Time.realtimeSinceStartup;
             var vertices = vertexPositions.Select(position => new Vertex(nextId++, position)).ToArray();
 
-            ConnectVertices(vertices, map, numberOfReverseNearestNeighbors);
+            ConnectVertices(vertices, distanceMatrix, numberOfReverseNearestNeighbors);
 
             Debug.LogFormat($"{nameof(ReverseNearestNeighborWaypointConnector)} ConnectVertices took {{0}} s", Time.realtimeSinceStartup - startTime);
 
             return vertices;
         }
 
-        public static void ConnectVertices(IReadOnlyCollection<Vertex> vertices, Bitmap map, int numberOfReverseNearestNeighbors = 1)
+        public static void ConnectVertices(IReadOnlyCollection<Vertex> vertices, Dictionary<(Vector2Int, Vector2Int), int> distanceMatrix, int numberOfReverseNearestNeighbors = 1)
         {
-            var vertexPositions = vertices.Select(v => v.Position).ToArray();
-            var distanceMatrix = MapUtilities.CalculateDistanceMatrix(map, vertexPositions);
-
             ConnectReverseNearestNeighbors(vertices, distanceMatrix, numberOfReverseNearestNeighbors);
 
             ConnectIslands(vertices, distanceMatrix);

--- a/Assets/Scripts/Map/Generators/Tile.cs
+++ b/Assets/Scripts/Map/Generators/Tile.cs
@@ -25,7 +25,7 @@ using System.Diagnostics;
 
 namespace Maes.Map.Generators
 {
-    public enum TileType
+    public enum TileType : byte
     {
         Room,
         Hall,
@@ -54,7 +54,7 @@ namespace Maes.Map.Generators
 
         public static bool IsWall(TileType tile)
         {
-            return (int)tile >= (int)TileType.Wall;
+            return (byte)tile >= (byte)TileType.Wall;
         }
 
         public static TileType[] Walls()

--- a/Assets/Scripts/Map/SlamMap.cs
+++ b/Assets/Scripts/Map/SlamMap.cs
@@ -272,7 +272,7 @@ namespace Maes.Map
             return _tiles[localCoordinate.x, localCoordinate.y];
         }
 
-        public enum SlamTileStatus
+        public enum SlamTileStatus : byte
         {
             Unseen,
             Open,

--- a/Assets/Scripts/Statistics/Cell.cs
+++ b/Assets/Scripts/Statistics/Cell.cs
@@ -33,10 +33,6 @@ namespace Maes.Statistics
         public bool IsCovered { get; private set; }
         public bool CanBeCovered { get; set; } = true;
 
-        // --- Redundant Coverage ---
-        public int CoverageTimeInTicks; // The amount of ticks that this cell has been covered
-        public int ExplorationTimeInTicks; // The amount of ticks that this has been explored
-
         //  --- Heatmap ---
         public int LastExplorationTimeInTicks; // The last time that this cell was seen by a robot 
         public int LastCoverageTimeInTicks; // The last time that this cell was covered by a robot
@@ -53,7 +49,6 @@ namespace Maes.Statistics
             }
 #endif
 
-            ExplorationTimeInTicks += 1;
             LastExplorationTimeInTicks = currentTimeTicks;
             IsExplored = true;
         }
@@ -67,7 +62,6 @@ namespace Maes.Statistics
             }
 #endif
 
-            CoverageTimeInTicks += 1;
             LastCoverageTimeInTicks = currenTimeTicks;
             IsCovered = true;
         }

--- a/Assets/Scripts/Statistics/Trackers/ExplorationTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/ExplorationTracker.cs
@@ -266,7 +266,6 @@ namespace Maes.Statistics.Trackers
                 if (!cell.IsExplored)
                 {
                     cell.LastExplorationTimeInTicks = CurrentTick;
-                    cell.ExplorationTimeInTicks += 1;
 
                     _newlyExploredTriangles.Add((index, cell));
                     ExploredTriangles++;

--- a/Assets/Scripts/Utilities/VisibilityJob.cs
+++ b/Assets/Scripts/Utilities/VisibilityJob.cs
@@ -33,6 +33,9 @@ namespace Maes.Utilities
     public struct VisibilityJob : IJob
     {
         [ReadOnly]
+        public bool InaccurateButFast;
+
+        [ReadOnly]
         public int Width;
 
         [ReadOnly]
@@ -68,14 +71,43 @@ namespace Maes.Utilities
                     continue;
                 }
 
-                for (var x = 0; x < Width; x++)
+                if (InaccurateButFast)
                 {
+                    // Top row
+                    for (var x = 1; x < Width - 1; x++)
+                    {
+                        GridRayTracingLineOfSight(x, 0, outerY);
+                    }
+
+                    // Bottom row
+                    for (var x = 1; x < Width - 1; x++)
+                    {
+                        GridRayTracingLineOfSight(x, Height - 1, outerY);
+                    }
+
+                    // Left column
                     for (var y = 0; y < Height; y++)
                     {
-                        var innerIndex = GetMapIndex(x, y);
-                        if (Hint.Likely(!GetMapValue(innerIndex)))
+                        GridRayTracingLineOfSight(0, y, outerY);
+                    }
+
+                    // Right column
+                    for (var y = 0; y < Height; y++)
+                    {
+                        GridRayTracingLineOfSight(Width - 1, y, outerY);
+                    }
+                }
+                else
+                {
+                    for (var x = 0; x < Width; x++)
+                    {
+                        for (var y = 0; y < Height; y++)
                         {
-                            GridRayTracingLineOfSight(x, y, outerY);
+                            var innerIndex = GetMapIndex(x, y);
+                            if (Hint.Likely(!GetMapValue(innerIndex)))
+                            {
+                                GridRayTracingLineOfSight(x, y, outerY);
+                            }
                         }
                     }
                 }

--- a/Assets/Tests/EditModeTests/Benchmarks/LineOfSightBenchmarks.cs
+++ b/Assets/Tests/EditModeTests/Benchmarks/LineOfSightBenchmarks.cs
@@ -31,7 +31,32 @@ namespace Tests.EditModeTests.Benchmarks
 
                 for (var i = 0; i < iterations; i++)
                 {
-                    result = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap);
+                    result = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap, maxDistance: 0, inaccurateButFast: false);
+                }
+
+                stopWatch.Stop();
+
+                Debug.LogFormat("Took {0} ms with {1} iterations", stopWatch.ElapsedMilliseconds, iterations);
+            }
+
+            Assert.Greater(result!.Count, 0);
+        }
+        [Test]
+        [Explicit]
+        public void VisibilityComputationInaccurateBenchmark()
+        {
+            const int iterations = 10;
+
+            Dictionary<Vector2Int, Bitmap> result = null;
+
+            using (var bitmap = BitmapUtilities.BitmapFromString(Map))
+            {
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                for (var i = 0; i < iterations; i++)
+                {
+                    result = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap, maxDistance: 0, inaccurateButFast: true);
                 }
 
                 stopWatch.Stop();

--- a/Assets/Tests/EditModeTests/ComputeVisibilityTest.cs
+++ b/Assets/Tests/EditModeTests/ComputeVisibilityTest.cs
@@ -286,7 +286,7 @@ namespace Tests.EditModeTests
         {
             using (var bitmap = BitmapUtilities.BitmapFromString(Map))
             {
-                var waypoints = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap);
+                var waypoints = GreedyMostVisibilityWaypointGenerator.ComputeVisibility(bitmap, maxDistance: 0, inaccurateButFast: false);
 
                 // Check that there are no waypoints inside the wall
                 foreach (var (waypoint, _) in waypoints)


### PR DESCRIPTION
Optimize Visibility calculations by only tracing to the border of the map. This is inaccurate though, but should be good enough for the things we use visibility calculations for. This is many times faster than the accurate version.

Multithread generating paths between vertices on patrolling map. This is especially noticable when using everyone connected to everyone and or on big maps.

Use a SortedSet in Greedy Most Visibility Waypoint Connector to avoid having to sort every iteration. (about 33% performance improvement).

Only calculate Distance Matrix once. This is extremely expensive and doing this multiple times was extremely slow.

Other small optimizations.

This takes about 30 seconds off the CI.