### PR TITLE
Don't use communication groups in snapshot

### DIFF
--- a/Assets/Scripts/Robot/CommunicationManager.cs
+++ b/Assets/Scripts/Robot/CommunicationManager.cs
@@ -292,9 +292,7 @@ namespace Maes.Robot
 
             if (GlobalSettings.ShouldWriteCsvResults && _localTickCounter % GlobalSettings.TicksPerStatsSnapShot == 0)
             {
-                PopulateCommunicationGroups();
-
-                CommunicationTracker.CreateSnapshot(_localTickCounter, _receivedMessagesLastTick, _sentMessagesLastTick, _communicationGroups);
+                CommunicationTracker.CreateSnapshot(_localTickCounter, _receivedMessagesLastTick, _sentMessagesLastTick);
             }
         }
 

--- a/Assets/Scripts/Simulation/SimulationBase.cs
+++ b/Assets/Scripts/Simulation/SimulationBase.cs
@@ -51,6 +51,8 @@ namespace Maes.Simulation
         public int SimulatedPhysicsTicks { get; private set; }
         public float SimulateTimeSeconds { get; private set; }
 
+        private float _startedRealTimeSeconds;
+
         public MapSpawner MapGenerator = null!;
 
         public TRobotSpawner RobotSpawner = null!;
@@ -105,6 +107,8 @@ namespace Maes.Simulation
         // Sets up the simulation by generating the map and spawning the robots
         public virtual void SetScenario(TScenario scenario)
         {
+            _startedRealTimeSeconds = Time.realtimeSinceStartup;
+
             _scenario = scenario;
             var mapInstance = Instantiate(MapGenerator, transform);
             _collisionMap = scenario.MapSpawner(mapInstance);
@@ -245,6 +249,8 @@ namespace Maes.Simulation
             {
                 Tracker.FinishStatistics();
             }
+
+            Debug.LogFormat("Simulation took {0}s total", Time.realtimeSinceStartup - _startedRealTimeSeconds);
         }
 
         public void ShowAllTags()

--- a/Assets/Scripts/Statistics/Snapshots/CommunicationSnapshot.cs
+++ b/Assets/Scripts/Statistics/Snapshots/CommunicationSnapshot.cs
@@ -10,19 +10,13 @@ namespace Maes.Statistics.Snapshots
     {
         public int Tick { get; private set; }
 
-        public bool AgentsInterconnected { get; private set; }
-
-        public float BiggestClusterPercentage { get; private set; }
-
         public int ReceivedMessageCount { get; private set; }
 
         public int SentMessageCount { get; private set; }
 
-        public CommunicationSnapshot(int tick, bool agentsInterconnected, float biggestClusterPercentage, int receivedMessageCount, int sentMessageCount)
+        public CommunicationSnapshot(int tick, int receivedMessageCount, int sentMessageCount)
         {
             Tick = tick;
-            AgentsInterconnected = agentsInterconnected;
-            BiggestClusterPercentage = biggestClusterPercentage;
             ReceivedMessageCount = receivedMessageCount;
             SentMessageCount = sentMessageCount;
         }
@@ -30,10 +24,6 @@ namespace Maes.Statistics.Snapshots
         public void WriteHeader(StreamWriter streamWriter, char delimiter)
         {
             streamWriter.Write(nameof(Tick));
-            streamWriter.Write(delimiter);
-            streamWriter.Write(nameof(AgentsInterconnected));
-            streamWriter.Write(delimiter);
-            streamWriter.Write(nameof(BiggestClusterPercentage));
             streamWriter.Write(delimiter);
             streamWriter.Write(nameof(ReceivedMessageCount));
             streamWriter.Write(delimiter);
@@ -44,10 +34,6 @@ namespace Maes.Statistics.Snapshots
         {
             streamWriter.Write(Tick);
             streamWriter.Write(delimiter);
-            streamWriter.Write(AgentsInterconnected);
-            streamWriter.Write(delimiter);
-            streamWriter.Write(BiggestClusterPercentage);
-            streamWriter.Write(delimiter);
             streamWriter.Write(ReceivedMessageCount);
             streamWriter.Write(delimiter);
             streamWriter.Write(SentMessageCount);
@@ -56,12 +42,10 @@ namespace Maes.Statistics.Snapshots
         public ReadOnlySpan<string> ReadRow(ReadOnlySpan<string> columns)
         {
             Tick = Convert.ToInt32(columns[0], CultureInfo.InvariantCulture);
-            AgentsInterconnected = Convert.ToBoolean(columns[1], CultureInfo.InvariantCulture);
-            BiggestClusterPercentage = Convert.ToSingle(columns[2], CultureInfo.InvariantCulture);
-            ReceivedMessageCount = Convert.ToInt32(columns[3], CultureInfo.InvariantCulture);
-            SentMessageCount = Convert.ToInt32(columns[4], CultureInfo.InvariantCulture);
+            ReceivedMessageCount = Convert.ToInt32(columns[1], CultureInfo.InvariantCulture);
+            SentMessageCount = Convert.ToInt32(columns[2], CultureInfo.InvariantCulture);
 
-            return columns[5..];
+            return columns[3..];
         }
     }
 }

--- a/Assets/Scripts/Statistics/Trackers/CommunicationTracker.cs
+++ b/Assets/Scripts/Statistics/Trackers/CommunicationTracker.cs
@@ -19,9 +19,6 @@
 // 
 // Original repository: https://github.com/MalteZA/MAES
 
-using System.Collections.Generic;
-using System.Linq;
-
 using Maes.Statistics.Snapshots;
 
 namespace Maes.Statistics.Trackers
@@ -30,42 +27,14 @@ namespace Maes.Statistics.Trackers
     {
         public CommunicationSnapshot LatestSnapshot { get; private set; }
 
-        public void CreateSnapshot(int tick, int receivedMessageCount, int sentMessageCount, HashSet<HashSet<int>> communicationGroups)
+        public void CreateSnapshot(int tick, int receivedMessageCount, int sentMessageCount)
         {
             if (tick == 0)
             {
                 return;
             }
 
-            var interconnected = CalculateInterconnected(communicationGroups);
-            var biggestClusterSizePercentage = CalculateBiggestClusterSizePercentage(communicationGroups);
-
-            LatestSnapshot = new CommunicationSnapshot(tick, interconnected, biggestClusterSizePercentage, receivedMessageCount, sentMessageCount);
-        }
-
-        private float CalculateBiggestClusterSizePercentage(HashSet<HashSet<int>> communicationGroups)
-        {
-            if (communicationGroups.Count == 0)
-            {
-                return 0f;
-            }
-
-            // if we have exactly one group, then every agent must be in it!
-            if (communicationGroups.Count == 1)
-            {
-                return 100.0f;
-            }
-            else
-            {
-                var totalRobots = communicationGroups.Sum(g => g.Count);
-                var biggestCluster = communicationGroups.Select(g => g.Count).Max();
-                return (float)biggestCluster / (float)totalRobots * 100f;
-            }
-        }
-
-        private bool CalculateInterconnected(HashSet<HashSet<int>> communicationGroups)
-        {
-            return communicationGroups.Count == 1;
+            LatestSnapshot = new CommunicationSnapshot(tick, receivedMessageCount, sentMessageCount);
         }
     }
 }


### PR DESCRIPTION
This removes AgentsInterconnected and BiggestClusterPercentage. These slowed down the runtime of the simulator a lot!